### PR TITLE
fix: handle null Xiaomi token plan responses safely

### DIFF
--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiProviderClient.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiProviderClient.kt
@@ -2,21 +2,16 @@ package org.zhavoronkov.tokenpulse.provider.xiaomi
 
 import com.google.gson.Gson
 import com.google.gson.JsonObject
+import com.google.gson.JsonSyntaxException
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import org.zhavoronkov.tokenpulse.model.Balance
-import org.zhavoronkov.tokenpulse.model.BalanceSnapshot
 import org.zhavoronkov.tokenpulse.model.ConnectionType
-import org.zhavoronkov.tokenpulse.model.Credits
 import org.zhavoronkov.tokenpulse.model.ProviderResult
-import org.zhavoronkov.tokenpulse.model.Tokens
 import org.zhavoronkov.tokenpulse.provider.HttpErrorHandler
 import org.zhavoronkov.tokenpulse.provider.ProviderClient
 import org.zhavoronkov.tokenpulse.provider.SessionParser
 import org.zhavoronkov.tokenpulse.settings.Account
 import org.zhavoronkov.tokenpulse.utils.TokenPulseLogger
-import java.math.BigDecimal
-import java.time.Instant
 
 /**
  * Provider client for Xiaomi MiMo platform.
@@ -76,42 +71,7 @@ class XiaomiProviderClient(
 
         return executeRequest(request) { body ->
             val json = gson.fromJson(body, JsonObject::class.java)
-            val code = json.getAsJsonPrimitive("code")?.asInt ?: -1
-
-            if (code != 0) {
-                val message = json.getAsJsonPrimitive("message")?.asString ?: "Unknown error"
-                return@executeRequest ProviderResult.Failure.AuthError("Xiaomi API error: $message")
-            }
-
-            val data = json.getAsJsonObject("data")
-            val balance = data.getAsJsonPrimitive("balance")?.asString?.toBigDecimalOrNull() ?: BigDecimal.ZERO
-            val giftBalance = data.getAsJsonPrimitive("giftBalance")?.asString?.toBigDecimalOrNull() ?: BigDecimal.ZERO
-            val cashBalance = data.getAsJsonPrimitive("cashBalance")?.asString?.toBigDecimalOrNull() ?: BigDecimal.ZERO
-            val currency = data.getAsJsonPrimitive("currency")?.asString ?: "USD"
-
-            TokenPulseLogger.Provider.debug(
-                "[$traceId] Xiaomi balance: $balance $currency (gift=$giftBalance, cash=$cashBalance)"
-            )
-
-            ProviderResult.Success(
-                BalanceSnapshot(
-                    accountId = account.id,
-                    connectionType = ConnectionType.XIAOMI_API,
-                    balance = Balance(
-                        credits = Credits(
-                            remaining = balance,
-                            total = null,
-                            used = null
-                        )
-                    ),
-                    timestamp = Instant.now(),
-                    metadata = mapOf(
-                        "currency" to currency,
-                        "giftBalance" to giftBalance.toPlainString(),
-                        "cashBalance" to cashBalance.toPlainString()
-                    )
-                )
-            )
+            XiaomiResponseParser.parseApiBalance(json, account)
         }
     }
 
@@ -125,50 +85,7 @@ class XiaomiProviderClient(
 
         return executeRequest(request) { body ->
             val json = gson.fromJson(body, JsonObject::class.java)
-            val code = json.getAsJsonPrimitive("code")?.asInt ?: -1
-
-            if (code != 0) {
-                val message = json.getAsJsonPrimitive("message")?.asString ?: "Unknown error"
-                return@executeRequest ProviderResult.Failure.AuthError("Xiaomi API error: $message")
-            }
-
-            val data = json.getAsJsonObject("data")
-            val monthUsage = data.getAsJsonObject("monthUsage")
-            val usagePercent = monthUsage?.getAsJsonPrimitive("percent")?.asDouble ?: 0.0
-
-            val items = monthUsage?.getAsJsonArray("items")
-            var usedCredits = 0L
-            var totalCredits = 0L
-            if (items != null && items.size() > 0) {
-                val item = items[0].asJsonObject
-                usedCredits = item.getAsJsonPrimitive("used")?.asLong ?: 0L
-                totalCredits = item.getAsJsonPrimitive("limit")?.asLong ?: 0L
-            }
-
-            TokenPulseLogger.Provider.debug(
-                "[$traceId] Token Plan: ${(usagePercent * 100).toInt()}% used, " +
-                    "$usedCredits/$totalCredits Credits"
-            )
-
-            ProviderResult.Success(
-                BalanceSnapshot(
-                    accountId = account.id,
-                    connectionType = ConnectionType.XIAOMI_TOKEN_PLAN,
-                    balance = Balance(
-                        tokens = Tokens(
-                            used = usedCredits,
-                            total = totalCredits,
-                            remaining = totalCredits - usedCredits
-                        )
-                    ),
-                    timestamp = Instant.now(),
-                    metadata = mapOf(
-                        "sessionUsed" to (usagePercent * 100).toInt().toString(),
-                        "planUsed" to usedCredits.toString(),
-                        "planTotal" to totalCredits.toString()
-                    )
-                )
-            )
+            XiaomiResponseParser.parseTokenPlanUsage(json, account)
         }
     }
 
@@ -198,14 +115,21 @@ class XiaomiProviderClient(
     }
 
     private fun executeRequest(request: Request, parser: (String) -> ProviderResult): ProviderResult {
-        val response = httpClient.newCall(request).execute()
-        val body = response.body?.string() ?: ""
+        return try {
+            httpClient.newCall(request).execute().use { response ->
+                val body = response.body?.string().orEmpty()
 
-        if (!response.isSuccessful) {
-            return HttpErrorHandler.mapHttpError(response.code, "Xiaomi")
+                if (!response.isSuccessful) {
+                    return HttpErrorHandler.mapHttpError(response.code, "Xiaomi")
+                }
+
+                parser(body)
+            }
+        } catch (e: JsonSyntaxException) {
+            ProviderResult.Failure.ParseError("Failed to parse Xiaomi response: ${e.message}")
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            ProviderResult.Failure.NetworkError("Failed to connect to Xiaomi: ${e.message}")
         }
-
-        return parser(body)
     }
 
     data class XiaomiSession(

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiResponseParser.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiResponseParser.kt
@@ -1,0 +1,164 @@
+package org.zhavoronkov.tokenpulse.provider.xiaomi
+
+import com.google.gson.JsonObject
+import org.zhavoronkov.tokenpulse.model.Balance
+import org.zhavoronkov.tokenpulse.model.BalanceSnapshot
+import org.zhavoronkov.tokenpulse.model.ConnectionType
+import org.zhavoronkov.tokenpulse.model.Credits
+import org.zhavoronkov.tokenpulse.model.ProviderResult
+import org.zhavoronkov.tokenpulse.model.Tokens
+import org.zhavoronkov.tokenpulse.settings.Account
+import java.math.BigDecimal
+import java.time.Instant
+
+/**
+ * Parses Xiaomi platform API responses into [ProviderResult] domain objects.
+ *
+ * Handles both the Xiaomi API balance endpoint and the Token Plan usage endpoint,
+ * including safe null handling for stopped/expired plans where the API returns
+ * `null` instead of expected objects or arrays.
+ */
+internal object XiaomiResponseParser {
+
+    /**
+     * Parse the Xiaomi API balance response (pay-as-you-go).
+     *
+     * Expected shape:
+     * ```json
+     * { "code": 0, "data": { "balance": "55.48", "giftBalance": "55.48", "cashBalance": "0.00", "currency": "USD" } }
+     * ```
+     */
+    fun parseApiBalance(json: JsonObject, account: Account): ProviderResult {
+        val envelopeError = checkEnvelope(json)
+        if (envelopeError != null) return envelopeError
+
+        val data = json.getObjectOrNull("data")
+        val balance = data?.getStringOrNull("balance")?.toBigDecimalOrNull() ?: BigDecimal.ZERO
+        val giftBalance = data?.getStringOrNull("giftBalance")?.toBigDecimalOrNull() ?: BigDecimal.ZERO
+        val cashBalance = data?.getStringOrNull("cashBalance")?.toBigDecimalOrNull() ?: BigDecimal.ZERO
+        val currency = data?.getStringOrNull("currency") ?: "USD"
+
+        return ProviderResult.Success(
+            BalanceSnapshot(
+                accountId = account.id,
+                connectionType = ConnectionType.XIAOMI_API,
+                balance = Balance(
+                    credits = Credits(remaining = balance, total = null, used = null)
+                ),
+                timestamp = Instant.now(),
+                metadata = mapOf(
+                    "currency" to currency,
+                    "giftBalance" to giftBalance.toPlainString(),
+                    "cashBalance" to cashBalance.toPlainString()
+                )
+            )
+        )
+    }
+
+    /**
+     * Parse the Xiaomi Token Plan usage response.
+     *
+     * Expected shape:
+     * ```json
+     * { "code": 0, "data": { "monthUsage": { "percent": 0.248, "items": [{ "used": 2727524596, "limit": 11000000000 }] } } }
+     * ```
+     *
+     * When a plan is stopped/expired, the API may return `null` for `data`,
+     * `monthUsage`, or `items`. This method handles all such cases gracefully.
+     */
+    fun parseTokenPlanUsage(json: JsonObject, account: Account): ProviderResult {
+        val envelopeError = checkEnvelope(json)
+        if (envelopeError != null) return envelopeError
+
+        val data = json.getObjectOrNull("data")
+        val monthUsage = data?.getObjectOrNull("monthUsage")
+        val usagePercent = monthUsage?.getAsDoubleOrZero("percent")
+
+        val items = monthUsage?.getArrayOrNull("items")
+        var usedCredits = 0L
+        var totalCredits = 0L
+        if (items != null && items.size() > 0) {
+            val item = items[0].asJsonObject
+            usedCredits = item.getLongOrZero("used")
+            totalCredits = item.getLongOrZero("limit")
+        }
+
+        // When totalCredits is 0 (no active plan), the percentage is meaningless.
+        // Report 100% used so the UI shows "0% remaining" instead of misleading "100% remaining".
+        val effectiveUsedPercent = if (totalCredits == 0L) 100 else ((usagePercent ?: 0.0) * 100).toInt()
+
+        val planStatus = if (totalCredits == 0L) "inactive" else "active"
+
+        return ProviderResult.Success(
+            BalanceSnapshot(
+                accountId = account.id,
+                connectionType = ConnectionType.XIAOMI_TOKEN_PLAN,
+                balance = Balance(
+                    tokens = Tokens(
+                        used = usedCredits,
+                        total = totalCredits,
+                        remaining = totalCredits - usedCredits
+                    )
+                ),
+                timestamp = Instant.now(),
+                metadata = mapOf(
+                    "sessionUsed" to effectiveUsedPercent.toString(),
+                    "planUsed" to usedCredits.toString(),
+                    "planTotal" to totalCredits.toString(),
+                    "planStatus" to planStatus
+                )
+            )
+        )
+    }
+
+    /**
+     * Check the Xiaomi API envelope for errors.
+     * Returns a [ProviderResult.Failure] if the response indicates an error, or `null` if successful.
+     */
+    private fun checkEnvelope(json: JsonObject): ProviderResult.Failure? {
+        val code = json.getAsIntOrMinusOne("code")
+        if (code != 0) {
+            val message = json.getStringOrNull("message") ?: "Unknown error"
+            return mapXiaomiApiError(code, message)
+        }
+        return null
+    }
+
+    /**
+     * Map Xiaomi API error codes and messages to appropriate [ProviderResult.Failure] types.
+     */
+    private fun mapXiaomiApiError(code: Int, message: String): ProviderResult.Failure {
+        val lowerMessage = message.lowercase()
+        return when {
+            lowerMessage.contains("token expired") ||
+                lowerMessage.contains("session") ||
+                lowerMessage.contains("unauthorized") ||
+                lowerMessage.contains("login") ->
+                ProviderResult.Failure.AuthError("Xiaomi API error: $message")
+            lowerMessage.contains("rate") || lowerMessage.contains("limit") || lowerMessage.contains("throttl") ->
+                ProviderResult.Failure.RateLimited("Xiaomi rate limit: $message")
+            else ->
+                ProviderResult.Failure.UnknownError("Xiaomi API error (code=$code): $message")
+        }
+    }
+
+    // -- Safe JSON accessors --
+
+    private fun JsonObject.getObjectOrNull(key: String): JsonObject? =
+        get(key)?.takeIf { it.isJsonObject }?.asJsonObject
+
+    private fun JsonObject.getArrayOrNull(key: String) =
+        get(key)?.takeIf { it.isJsonArray }?.asJsonArray
+
+    private fun JsonObject.getStringOrNull(key: String): String? =
+        get(key)?.takeIf { it.isJsonPrimitive }?.asString
+
+    private fun JsonObject.getAsIntOrMinusOne(key: String): Int =
+        get(key)?.takeIf { it.isJsonPrimitive }?.asInt ?: -1
+
+    private fun JsonObject.getAsDoubleOrZero(key: String): Double =
+        get(key)?.takeIf { it.isJsonPrimitive }?.asDouble ?: 0.0
+
+    private fun JsonObject.getLongOrZero(key: String): Long =
+        get(key)?.takeIf { it.isJsonPrimitive }?.asLong ?: 0L
+}

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiProviderClientTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiProviderClientTest.kt
@@ -219,6 +219,76 @@ class XiaomiProviderClientTest {
     }
 
     @Test
+    fun `fetchTokenPlanUsage handles null monthUsage gracefully`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """{"code":0,"message":"","data":{"monthUsage":null}}"""
+                )
+        )
+
+        val result = client.fetchBalance(
+            account(ConnectionType.XIAOMI_TOKEN_PLAN),
+            validSession
+        )
+
+        assertTrue(result is ProviderResult.Success)
+        val success = result as ProviderResult.Success
+        assertEquals(0L, success.snapshot.balance.tokens?.used)
+        assertEquals(0L, success.snapshot.balance.tokens?.total)
+        assertEquals(0L, success.snapshot.balance.tokens?.remaining)
+        // totalCredits=0 → sessionUsed=100 → UI shows "0% remaining"
+        assertEquals("100", success.snapshot.metadata["sessionUsed"])
+    }
+
+    @Test
+    fun `fetchTokenPlanUsage handles null items array gracefully`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """{"code":0,"message":"","data":{"monthUsage":{"percent":0.0,"items":null}}}"""
+                )
+        )
+
+        val result = client.fetchBalance(
+            account(ConnectionType.XIAOMI_TOKEN_PLAN),
+            validSession
+        )
+
+        assertTrue(result is ProviderResult.Success)
+        val success = result as ProviderResult.Success
+        assertEquals(0L, success.snapshot.balance.tokens?.used)
+        assertEquals(0L, success.snapshot.balance.tokens?.total)
+        assertEquals(0L, success.snapshot.balance.tokens?.remaining)
+        assertEquals("100", success.snapshot.metadata["sessionUsed"])
+    }
+
+    @Test
+    fun `fetchTokenPlanUsage handles null data gracefully`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """{"code":0,"message":"","data":null}"""
+                )
+        )
+
+        val result = client.fetchBalance(
+            account(ConnectionType.XIAOMI_TOKEN_PLAN),
+            validSession
+        )
+
+        assertTrue(result is ProviderResult.Success)
+        val success = result as ProviderResult.Success
+        assertEquals(0L, success.snapshot.balance.tokens?.used)
+        assertEquals(0L, success.snapshot.balance.tokens?.total)
+        assertEquals(0L, success.snapshot.balance.tokens?.remaining)
+        assertEquals("100", success.snapshot.metadata["sessionUsed"])
+    }
+
+    @Test
     fun `fetchApiBalance returns AuthError when code is not zero`() {
         server.enqueue(
             MockResponse()

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiResponseParserTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiResponseParserTest.kt
@@ -1,0 +1,384 @@
+package org.zhavoronkov.tokenpulse.provider.xiaomi
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.zhavoronkov.tokenpulse.model.ConnectionType
+import org.zhavoronkov.tokenpulse.model.ProviderResult
+import org.zhavoronkov.tokenpulse.settings.Account
+
+class XiaomiResponseParserTest {
+
+    private val gson = Gson()
+
+    private fun account() = Account(
+        id = "test-account",
+        connectionType = ConnectionType.XIAOMI_API,
+        authType = ConnectionType.XIAOMI_API.defaultAuthType
+    )
+
+    private fun json(raw: String): JsonObject = gson.fromJson(raw, JsonObject::class.java)
+
+    // ── parseApiBalance ──────────────────────────────────────────────
+
+    @Nested
+    inner class ParseApiBalance {
+
+        @Test
+        fun `parses full balance response`() {
+            val result = XiaomiResponseParser.parseApiBalance(
+                json("""{"code":0,"data":{"balance":"55.48","giftBalance":"10.00","cashBalance":"45.48","currency":"USD"}}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Success)
+            val snapshot = (result as ProviderResult.Success).snapshot
+            assertEquals("55.48", snapshot.balance.credits?.remaining?.toPlainString())
+            assertEquals(ConnectionType.XIAOMI_API, snapshot.connectionType)
+            assertEquals("USD", snapshot.metadata["currency"])
+            assertEquals("10.00", snapshot.metadata["giftBalance"])
+            assertEquals("45.48", snapshot.metadata["cashBalance"])
+        }
+
+        @Test
+        fun `defaults missing fields to zero and USD`() {
+            val result = XiaomiResponseParser.parseApiBalance(
+                json("""{"code":0,"data":{}}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Success)
+            val snapshot = (result as ProviderResult.Success).snapshot
+            assertEquals("0", snapshot.balance.credits?.remaining?.toPlainString())
+            assertEquals("USD", snapshot.metadata["currency"])
+            assertEquals("0", snapshot.metadata["giftBalance"])
+            assertEquals("0", snapshot.metadata["cashBalance"])
+        }
+
+        @Test
+        fun `handles null data`() {
+            val result = XiaomiResponseParser.parseApiBalance(
+                json("""{"code":0,"data":null}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Success)
+            val snapshot = (result as ProviderResult.Success).snapshot
+            assertEquals("0", snapshot.balance.credits?.remaining?.toPlainString())
+        }
+
+        @Test
+        fun `handles missing data field`() {
+            val result = XiaomiResponseParser.parseApiBalance(
+                json("""{"code":0}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Success)
+            val snapshot = (result as ProviderResult.Success).snapshot
+            assertEquals("0", snapshot.balance.credits?.remaining?.toPlainString())
+        }
+
+        @Test
+        fun `returns AuthError for token expired message`() {
+            val result = XiaomiResponseParser.parseApiBalance(
+                json("""{"code":-1,"message":"Token expired"}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Failure.AuthError)
+            assertEquals(
+                "Xiaomi API error: Token expired",
+                (result as ProviderResult.Failure.AuthError).message
+            )
+        }
+
+        @Test
+        fun `returns AuthError for session message`() {
+            val result = XiaomiResponseParser.parseApiBalance(
+                json("""{"code":-1,"message":"Session timeout"}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Failure.AuthError)
+        }
+
+        @Test
+        fun `returns AuthError for unauthorized message`() {
+            val result = XiaomiResponseParser.parseApiBalance(
+                json("""{"code":-1,"message":"Unauthorized access"}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Failure.AuthError)
+        }
+
+        @Test
+        fun `returns AuthError for login message`() {
+            val result = XiaomiResponseParser.parseApiBalance(
+                json("""{"code":-1,"message":"Please login again"}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Failure.AuthError)
+        }
+
+        @Test
+        fun `returns RateLimited for rate message`() {
+            val result = XiaomiResponseParser.parseApiBalance(
+                json("""{"code":-1,"message":"Rate limit exceeded"}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Failure.RateLimited)
+            assertEquals(
+                "Xiaomi rate limit: Rate limit exceeded",
+                (result as ProviderResult.Failure.RateLimited).message
+            )
+        }
+
+        @Test
+        fun `returns RateLimited for throttle message`() {
+            val result = XiaomiResponseParser.parseApiBalance(
+                json("""{"code":-1,"message":"Throttled"}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Failure.RateLimited)
+        }
+
+        @Test
+        fun `returns UnknownError for unrecognized error`() {
+            val result = XiaomiResponseParser.parseApiBalance(
+                json("""{"code":-1,"message":"Something went wrong"}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Failure.UnknownError)
+            assertEquals(
+                "Xiaomi API error (code=-1): Something went wrong",
+                (result as ProviderResult.Failure.UnknownError).message
+            )
+        }
+
+        @Test
+        fun `returns UnknownError with default message when message is missing`() {
+            val result = XiaomiResponseParser.parseApiBalance(
+                json("""{"code":-1}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Failure.UnknownError)
+            assertEquals(
+                "Xiaomi API error (code=-1): Unknown error",
+                (result as ProviderResult.Failure.UnknownError).message
+            )
+        }
+    }
+
+    // ── parseTokenPlanUsage ──────────────────────────────────────────
+
+    @Nested
+    inner class ParseTokenPlanUsage {
+
+        @Test
+        fun `parses full token plan response`() {
+            val result = XiaomiResponseParser.parseTokenPlanUsage(
+                json("""{"code":0,"data":{"monthUsage":{"percent":0.248,"items":[{"used":2727524596,"limit":11000000000}]}}}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Success)
+            val snapshot = (result as ProviderResult.Success).snapshot
+            assertEquals(ConnectionType.XIAOMI_TOKEN_PLAN, snapshot.connectionType)
+            assertEquals(2727524596L, snapshot.balance.tokens?.used)
+            assertEquals(11000000000L, snapshot.balance.tokens?.total)
+            assertEquals(8272475404L, snapshot.balance.tokens?.remaining)
+            assertEquals("active", snapshot.metadata["planStatus"])
+            // 0.248 * 100 = 24 (int truncation)
+            assertEquals("24", snapshot.metadata["sessionUsed"])
+        }
+
+        @Test
+        fun `handles null data`() {
+            val result = XiaomiResponseParser.parseTokenPlanUsage(
+                json("""{"code":0,"data":null}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Success)
+            val snapshot = (result as ProviderResult.Success).snapshot
+            assertEquals(0L, snapshot.balance.tokens?.used)
+            assertEquals(0L, snapshot.balance.tokens?.total)
+            assertEquals(0L, snapshot.balance.tokens?.remaining)
+            assertEquals("100", snapshot.metadata["sessionUsed"])
+            assertEquals("inactive", snapshot.metadata["planStatus"])
+        }
+
+        @Test
+        fun `handles missing data field`() {
+            val result = XiaomiResponseParser.parseTokenPlanUsage(
+                json("""{"code":0}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Success)
+            val snapshot = (result as ProviderResult.Success).snapshot
+            assertEquals(0L, snapshot.balance.tokens?.total)
+            assertEquals("inactive", snapshot.metadata["planStatus"])
+        }
+
+        @Test
+        fun `handles null monthUsage`() {
+            val result = XiaomiResponseParser.parseTokenPlanUsage(
+                json("""{"code":0,"data":{"monthUsage":null}}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Success)
+            val snapshot = (result as ProviderResult.Success).snapshot
+            assertEquals(0L, snapshot.balance.tokens?.total)
+            assertEquals("100", snapshot.metadata["sessionUsed"])
+            assertEquals("inactive", snapshot.metadata["planStatus"])
+        }
+
+        @Test
+        fun `handles missing monthUsage field`() {
+            val result = XiaomiResponseParser.parseTokenPlanUsage(
+                json("""{"code":0,"data":{}}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Success)
+            val snapshot = (result as ProviderResult.Success).snapshot
+            assertEquals(0L, snapshot.balance.tokens?.total)
+            assertEquals("inactive", snapshot.metadata["planStatus"])
+        }
+
+        @Test
+        fun `handles null items array`() {
+            val result = XiaomiResponseParser.parseTokenPlanUsage(
+                json("""{"code":0,"data":{"monthUsage":{"percent":0.5,"items":null}}}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Success)
+            val snapshot = (result as ProviderResult.Success).snapshot
+            assertEquals(0L, snapshot.balance.tokens?.used)
+            assertEquals(0L, snapshot.balance.tokens?.total)
+            assertEquals("100", snapshot.metadata["sessionUsed"])
+            assertEquals("inactive", snapshot.metadata["planStatus"])
+        }
+
+        @Test
+        fun `handles empty items array`() {
+            val result = XiaomiResponseParser.parseTokenPlanUsage(
+                json("""{"code":0,"data":{"monthUsage":{"percent":0.5,"items":[]}}}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Success)
+            val snapshot = (result as ProviderResult.Success).snapshot
+            assertEquals(0L, snapshot.balance.tokens?.used)
+            assertEquals(0L, snapshot.balance.tokens?.total)
+            assertEquals("100", snapshot.metadata["sessionUsed"])
+            assertEquals("inactive", snapshot.metadata["planStatus"])
+        }
+
+        @Test
+        fun `handles missing items field`() {
+            val result = XiaomiResponseParser.parseTokenPlanUsage(
+                json("""{"code":0,"data":{"monthUsage":{"percent":0.5}}}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Success)
+            val snapshot = (result as ProviderResult.Success).snapshot
+            assertEquals(0L, snapshot.balance.tokens?.total)
+            assertEquals("inactive", snapshot.metadata["planStatus"])
+        }
+
+        @Test
+        fun `handles missing percent field`() {
+            val result = XiaomiResponseParser.parseTokenPlanUsage(
+                json("""{"code":0,"data":{"monthUsage":{"items":[{"used":100,"limit":200}]}}}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Success)
+            val snapshot = (result as ProviderResult.Success).snapshot
+            assertEquals(100L, snapshot.balance.tokens?.used)
+            assertEquals(200L, snapshot.balance.tokens?.total)
+            assertEquals("active", snapshot.metadata["planStatus"])
+            // percent defaults to 0.0 → 0 * 100 = 0
+            assertEquals("0", snapshot.metadata["sessionUsed"])
+        }
+
+        @Test
+        fun `reports inactive plan when totalCredits is zero`() {
+            val result = XiaomiResponseParser.parseTokenPlanUsage(
+                json("""{"code":0,"data":{"monthUsage":{"percent":0.0,"items":[{"used":0,"limit":0}]}}}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Success)
+            val snapshot = (result as ProviderResult.Success).snapshot
+            assertEquals("inactive", snapshot.metadata["planStatus"])
+            assertEquals("100", snapshot.metadata["sessionUsed"])
+        }
+
+        @Test
+        fun `reports active plan when totalCredits is positive`() {
+            val result = XiaomiResponseParser.parseTokenPlanUsage(
+                json("""{"code":0,"data":{"monthUsage":{"percent":0.75,"items":[{"used":750,"limit":1000}]}}}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Success)
+            val snapshot = (result as ProviderResult.Success).snapshot
+            assertEquals("active", snapshot.metadata["planStatus"])
+            assertEquals("75", snapshot.metadata["sessionUsed"])
+            assertEquals(750L, snapshot.balance.tokens?.used)
+            assertEquals(1000L, snapshot.balance.tokens?.total)
+            assertEquals(250L, snapshot.balance.tokens?.remaining)
+        }
+
+        @Test
+        fun `returns AuthError for expired session`() {
+            val result = XiaomiResponseParser.parseTokenPlanUsage(
+                json("""{"code":-1,"message":"Token expired"}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Failure.AuthError)
+        }
+
+        @Test
+        fun `returns RateLimited for rate limit error`() {
+            val result = XiaomiResponseParser.parseTokenPlanUsage(
+                json("""{"code":-1,"message":"Rate limit exceeded"}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Failure.RateLimited)
+        }
+
+        @Test
+        fun `returns UnknownError for other errors`() {
+            val result = XiaomiResponseParser.parseTokenPlanUsage(
+                json("""{"code":500,"message":"Internal server error"}"""),
+                account()
+            )
+
+            assertTrue(result is ProviderResult.Failure.UnknownError)
+            assertEquals(
+                "Xiaomi API error (code=500): Internal server error",
+                (result as ProviderResult.Failure.UnknownError).message
+            )
+        }
+
+    }
+}


### PR DESCRIPTION
## Summary

- fix Xiaomi token plan parsing when the API returns `null` for `data`, `monthUsage`, or `items`
- extract Xiaomi response parsing into a dedicated `XiaomiResponseParser`
- add focused tests for parser and provider behavior

## Problem

Xiaomi token plan refresh could throw a `ClassCastException` when the platform returned `JsonNull` instead of the expected array/object structure for stopped or expired plans:

```
java.lang.ClassCastException: class com.google.gson.JsonNull cannot be cast to class com.google.gson.JsonArray
    at com.google.gson.JsonObject.getAsJsonArray(JsonObject.java:211)
    at ...XiaomiProviderClient.fetchTokenPlanUsage$lambda$1(XiaomiProviderClient.kt:139)
```

## Changes

- replace unsafe `getAsJsonArray()` / `getAsJsonObject()` calls with null-safe accessor extensions (`getArrayOrNull`, `getObjectOrNull`, `getStringOrNull`, etc.)
- move Xiaomi response mapping logic into `XiaomiResponseParser`
- preserve expected inactive-plan behavior when usage data is absent (0 tokens, "inactive" status)
- expand Xiaomi provider tests
- add dedicated parser tests covering success, null/missing fields, and error envelopes

## Validation

- `./gradlew test --tests "org.zhavoronkov.tokenpulse.provider.xiaomi.*"` — all tests pass
- Xiaomi package line coverage: **95.0%** (114/120)