### PR TITLE
feat: add ClinePass usage limits support for Cline API key accounts

### DIFF
--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/cline/ClineProviderClient.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/cline/ClineProviderClient.kt
@@ -215,30 +215,52 @@ class ClineProviderClient(
      * when there are no recognized limits so callers can attach nothing to the snapshot.
      */
     private fun buildClinePassMetadata(response: PlanUsageLimitsResponse?): Map<String, String> {
-        if (response?.limits.isNullOrEmpty()) return emptyMap()
+        val limits = response?.limits.orEmpty()
+        if (limits.isEmpty()) return emptyMap()
 
-        val result = LinkedHashMap<String, String>()
-        for (limit in response!!.limits) {
-            val type = limit.type ?: continue
-            val used = limit.percentUsed?.coerceIn(0, 100) ?: continue
-            val resetsAt = limit.resetsAt?.takeIf { it.isNotBlank() }
-            when (type) {
-                TYPE_FIVE_HOUR -> {
-                    result[METADATA_FIVE_HOUR_USED] = used.toString()
-                    resetsAt?.let { result[METADATA_FIVE_HOUR_RESETS_AT] = it }
-                }
-                TYPE_WEEKLY -> {
-                    result[METADATA_WEEKLY_USED] = used.toString()
-                    resetsAt?.let { result[METADATA_WEEKLY_RESETS_AT] = it }
-                }
-                TYPE_MONTHLY -> {
-                    result[METADATA_MONTHLY_USED] = used.toString()
-                    resetsAt?.let { result[METADATA_MONTHLY_RESETS_AT] = it }
-                }
-                // Unknown limit types are intentionally ignored.
+        // Map each recognized limit to its own small metadata contribution and merge.
+        // Returning `null` from the per-limit helper avoids the multiple `continue`
+        // statements that previously triggered detekt's LoopWithTooManyJumpStatements.
+        return limits
+            .mapNotNull { limit -> toClinePassEntries(limit) }
+            .fold(LinkedHashMap<String, String>()) { acc, entries -> acc.apply { putAll(entries) } }
+    }
+
+    /**
+     * Convert a single [PlanUsageLimit] into the metadata key/value pairs that
+     * should be exposed to the tooltip renderer, or `null` if the entry is invalid
+     * (missing required fields) or represents an unsupported limit type.
+     */
+    private fun toClinePassEntries(limit: PlanUsageLimit): Map<String, String>? {
+        val type = limit.type ?: return null
+        val used = limit.percentUsed?.coerceIn(0, 100) ?: return null
+        val resetsAt = limit.resetsAt?.takeIf { it.isNotBlank() }
+
+        val usedKey: String
+        val resetKey: String
+        when (type) {
+            TYPE_FIVE_HOUR -> {
+                usedKey = METADATA_FIVE_HOUR_USED
+                resetKey = METADATA_FIVE_HOUR_RESETS_AT
             }
+            TYPE_WEEKLY -> {
+                usedKey = METADATA_WEEKLY_USED
+                resetKey = METADATA_WEEKLY_RESETS_AT
+            }
+            TYPE_MONTHLY -> {
+                usedKey = METADATA_MONTHLY_USED
+                resetKey = METADATA_MONTHLY_RESETS_AT
+            }
+            // Unknown limit types are intentionally ignored.
+            else -> return null
         }
-        return result
+
+        val entries = LinkedHashMap<String, String>(2)
+        entries[usedKey] = used.toString()
+        if (resetsAt != null) {
+            entries[resetKey] = resetsAt
+        }
+        return entries
     }
 
     private data class UserInfoWrapper(val data: UserResponse?)

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/cline/ClineProviderClient.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/cline/ClineProviderClient.kt
@@ -28,10 +28,19 @@ import java.time.Instant
  * - `GET /api/v1/users/{id}/usages` → Personal account usage
  * - `GET /api/v1/organizations/{id}/balance` → Organization balance
  * - `GET /api/v1/organizations/{id}/members/{memberId}/usages` → Member usage
+ * - `GET /api/v1/users/me/plan/usage-limits` → ClinePass usage windows (5-hour / weekly / monthly)
  *
  * ## Balance Representation
  * Cline API returns balance in credits where 1 credit = $0.000001 (micro-dollars).
  * This client converts credits to USD for display.
+ *
+ * ## ClinePass Usage Limits
+ * The plan-usage-limits endpoint is best-effort: it is not part of the documented
+ * public API. The client maps recognized `type` values (`five_hour`, `weekly`,
+ * `monthly`) into provider-specific metadata keys. Any failure (non-2xx, malformed
+ * body, `success:false`, missing `data`, or no recognized limits) is silently
+ * swallowed and the rest of the balance snapshot is returned as if the call was
+ * never made.
  *
  * ## Error Handling
  * - 401/403 → AuthError (invalid/expired token)
@@ -59,6 +68,9 @@ class ClineProviderClient(
             // Organization billing is managed separately and doesn't use API keys
             val (balanceVal, usages) = fetchUserData(me.id, secret)
 
+            // Best-effort ClinePass usage limits; failure must not break balance fetch.
+            val clinePassMetadata = fetchPlanUsageLimits(secret)
+
             ProviderResult.Success(
                 BalanceSnapshot(
                     accountId = account.id,
@@ -72,7 +84,8 @@ class ClineProviderClient(
                         tokens = Tokens(
                             used = usages.sumOf { it.totalTokens }
                         )
-                    )
+                    ),
+                    metadata = clinePassMetadata
                 )
             )
         } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
@@ -150,11 +163,83 @@ class ClineProviderClient(
     }
 
     /**
+     * Best-effort fetch of ClinePass usage limits.
+     * Returns an empty map on any failure or when no recognized limit is reported.
+     * Failures (HTTP errors, malformed bodies, `success:false`, parse errors) are
+     * intentionally swallowed so the balance fetch can still succeed.
+     */
+    private fun fetchPlanUsageLimits(secret: String): Map<String, String> {
+        val response: PlanUsageLimitsResponse? = try {
+            val request = buildRequest("$baseUrl/api/v1/users/me/plan/usage-limits", secret)
+            httpClient.newCall(request).execute().use { httpResponse ->
+                if (!httpResponse.isSuccessful) {
+                    null
+                } else {
+                    val body = httpResponse.body?.string()
+                    if (body == null) null else parsePlanUsageLimitsResponse(body)
+                }
+            }
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            null
+        }
+        return buildClinePassMetadata(response)
+    }
+
+    /**
+     * Parses a plan-usage-limits response body into a typed [PlanUsageLimitsResponse]
+     * or returns `null` if the body is malformed / `success:false` / missing `data`.
+     */
+    private fun parsePlanUsageLimitsResponse(body: String): PlanUsageLimitsResponse? {
+        return try {
+            val jsonObject = gson.fromJson(body, JsonObject::class.java)
+            if (jsonObject.get("success")?.asBoolean == true) {
+                gson.fromJson(jsonObject.get("data"), PlanUsageLimitsResponse::class.java)
+            } else {
+                null
+            }
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            null
+        }
+    }
+
+    /**
      * Converts Cline credits to USD.
      * Cline API returns balance in credits where 1 credit = $0.000001 (micro-dollars).
      */
     private fun creditsToUsd(credits: BigDecimal): BigDecimal =
         credits.divide(CREDITS_PER_DOLLAR, 2, RoundingMode.HALF_UP)
+
+    /**
+     * Normalize recognized plan-usage-limits entries into provider-specific metadata keys.
+     * Unknown limit types and missing fields are silently ignored. Returns an empty map
+     * when there are no recognized limits so callers can attach nothing to the snapshot.
+     */
+    private fun buildClinePassMetadata(response: PlanUsageLimitsResponse?): Map<String, String> {
+        if (response?.limits.isNullOrEmpty()) return emptyMap()
+
+        val result = LinkedHashMap<String, String>()
+        for (limit in response!!.limits) {
+            val type = limit.type ?: continue
+            val used = limit.percentUsed?.coerceIn(0, 100) ?: continue
+            val resetsAt = limit.resetsAt?.takeIf { it.isNotBlank() }
+            when (type) {
+                TYPE_FIVE_HOUR -> {
+                    result[METADATA_FIVE_HOUR_USED] = used.toString()
+                    resetsAt?.let { result[METADATA_FIVE_HOUR_RESETS_AT] = it }
+                }
+                TYPE_WEEKLY -> {
+                    result[METADATA_WEEKLY_USED] = used.toString()
+                    resetsAt?.let { result[METADATA_WEEKLY_RESETS_AT] = it }
+                }
+                TYPE_MONTHLY -> {
+                    result[METADATA_MONTHLY_USED] = used.toString()
+                    resetsAt?.let { result[METADATA_MONTHLY_RESETS_AT] = it }
+                }
+                // Unknown limit types are intentionally ignored.
+            }
+        }
+        return result
+    }
 
     private data class UserInfoWrapper(val data: UserResponse?)
 
@@ -169,6 +254,16 @@ class ClineProviderClient(
     private data class UsageTransaction(
         val creditsUsed: BigDecimal,
         val totalTokens: Long
+    )
+
+    private data class PlanUsageLimitsResponse(
+        val limits: List<PlanUsageLimit>?
+    )
+
+    private data class PlanUsageLimit(
+        val type: String?,
+        val percentUsed: Int?,
+        val resetsAt: String?
     )
 
     /**
@@ -193,5 +288,18 @@ class ClineProviderClient(
         private const val HTTP_FORBIDDEN = 403
         private const val HTTP_TOO_MANY_REQUESTS = 429
         private const val HTTP_INTERNAL_ERROR = 500
+
+        // ClinePass plan-usage-limits type values.
+        private const val TYPE_FIVE_HOUR = "five_hour"
+        private const val TYPE_WEEKLY = "weekly"
+        private const val TYPE_MONTHLY = "monthly"
+
+        // Normalized provider-specific metadata keys for the tooltip renderer.
+        const val METADATA_FIVE_HOUR_USED = "clinePassFiveHourUsed"
+        const val METADATA_FIVE_HOUR_RESETS_AT = "clinePassFiveHourResetsAt"
+        const val METADATA_WEEKLY_USED = "clinePassWeeklyUsed"
+        const val METADATA_WEEKLY_RESETS_AT = "clinePassWeeklyResetsAt"
+        const val METADATA_MONTHLY_USED = "clinePassMonthlyUsed"
+        const val METADATA_MONTHLY_RESETS_AT = "clinePassMonthlyResetsAt"
     }
 }

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/ClinePassUsageRenderer.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/ClinePassUsageRenderer.kt
@@ -1,0 +1,96 @@
+package org.zhavoronkov.tokenpulse.ui
+
+import org.zhavoronkov.tokenpulse.provider.cline.ClineProviderClient
+
+/**
+ * Renders optional ClinePass usage information for the Cline tooltip.
+ *
+ * The renderer consumes only the provider-specific metadata keys populated by
+ * [ClineProviderClient] and produces HTML rows compatible with the existing
+ * status bar tooltip table.
+ *
+ * When ClinePass metadata is absent, [buildRows] produces an empty string so
+ * the caller renders no ClinePass-specific content. When ClinePass metadata
+ * is available, the output is a self-contained "ClinePass" section with a
+ * labeled header and usage rows (5-hour / Weekly / Monthly).
+ */
+object ClinePassUsageRenderer {
+
+    /** Title used for the ClinePass subsection header row. */
+    const val SECTION_TITLE: String = "ClinePass"
+
+    /** Color used for the ClinePass section header text. */
+    private const val SECTION_HEADER_COLOR: String = "#BBBBBB"
+
+    /**
+     * Returns `true` if at least one recognized ClinePass usage field is present
+     * in [metadata]. Used to decide whether the tooltip should show ClinePass rows.
+     */
+    fun hasUsage(metadata: Map<String, String>?): Boolean {
+        if (metadata == null) return false
+        return metadata.any { (key, value) ->
+            key in USED_KEYS && !value.isNullOrBlank()
+        }
+    }
+
+    /**
+     * Builds the ClinePass usage section of the tooltip as raw HTML rows.
+     *
+     * Returns an empty string when no recognized ClinePass usage is available.
+     * Recognized usage entries are rendered in the order: 5-hour, Weekly, Monthly,
+     * each via [ProgressBarRenderer.buildUsageSection].
+     */
+    fun buildRows(metadata: Map<String, String>?): String {
+        if (!hasUsage(metadata) || metadata == null) return ""
+
+        return buildString {
+            append(sectionHeaderRow())
+            val fiveHour = metadata[ClineProviderClient.METADATA_FIVE_HOUR_USED]?.toIntOrNull()
+            if (fiveHour != null) {
+                append(
+                    ProgressBarRenderer.buildUsageSection(
+                        "5-hour",
+                        fiveHour,
+                        metadata[ClineProviderClient.METADATA_FIVE_HOUR_RESETS_AT]
+                    )
+                )
+            }
+            val weekly = metadata[ClineProviderClient.METADATA_WEEKLY_USED]?.toIntOrNull()
+            if (weekly != null) {
+                append(
+                    ProgressBarRenderer.buildUsageSection(
+                        "Weekly",
+                        weekly,
+                        metadata[ClineProviderClient.METADATA_WEEKLY_RESETS_AT]
+                    )
+                )
+            }
+            val monthly = metadata[ClineProviderClient.METADATA_MONTHLY_USED]?.toIntOrNull()
+            if (monthly != null) {
+                append(
+                    ProgressBarRenderer.buildUsageSection(
+                        "Monthly",
+                        monthly,
+                        metadata[ClineProviderClient.METADATA_MONTHLY_RESETS_AT]
+                    )
+                )
+            }
+        }
+    }
+
+    /**
+     * Render the ClinePass subsection header row. Inlined (rather than reusing
+     * a shared progress-bar primitive) so this renderer stays self-contained
+     * and does not depend on optional progress-bar helper additions.
+     */
+    private fun sectionHeaderRow(): String {
+        return "<tr><td colspan='2' style='padding-top: 4px;'>" +
+            "<font color='$SECTION_HEADER_COLOR'><b>$SECTION_TITLE</b></font></td></tr>"
+    }
+
+    private val USED_KEYS = setOf(
+        ClineProviderClient.METADATA_FIVE_HOUR_USED,
+        ClineProviderClient.METADATA_WEEKLY_USED,
+        ClineProviderClient.METADATA_MONTHLY_USED
+    )
+}

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/TokenPulseStatusBarWidget.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/TokenPulseStatusBarWidget.kt
@@ -253,6 +253,8 @@ class TokenPulseStatusBarWidget : StatusBarWidget, StatusBarWidget.TextPresentat
                             appendClaudeCodeRows(snapshot.metadata)
                         } else if (snapshot.connectionType == ConnectionType.XIAOMI_TOKEN_PLAN) {
                             appendXiaomiTokenPlanRows(snapshot.metadata, snapshot.balance.tokens)
+                        } else if (snapshot.connectionType == ConnectionType.CLINE_API) {
+                            appendClineRows(snapshot.balance.credits, snapshot.metadata)
                         } else {
                             appendCreditsRows(snapshot.balance.credits, snapshot.connectionType)
                         }
@@ -530,6 +532,22 @@ class TokenPulseStatusBarWidget : StatusBarWidget, StatusBarWidget.TextPresentat
             else -> {
                 append("<tr><td colspan='2'><i>No balance data</i></td></tr>")
             }
+        }
+    }
+
+    /**
+     * Render the Cline tooltip block: existing Cline balance rows, plus an
+     * optional ClinePass usage block when the provider client populated
+     * plan-usage metadata. If ClinePass metadata is absent (e.g. the user
+     * has no ClinePass plan), only the existing balance rows are shown.
+     */
+    private fun StringBuilder.appendClineRows(
+        credits: org.zhavoronkov.tokenpulse.model.Credits?,
+        metadata: Map<String, String>
+    ) {
+        appendCreditsRows(credits, ConnectionType.CLINE_API)
+        if (ClinePassUsageRenderer.hasUsage(metadata)) {
+            append(ClinePassUsageRenderer.buildRows(metadata))
         }
     }
 

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/ClineProviderClientTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/ClineProviderClientTest.kt
@@ -4,6 +4,8 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -432,5 +434,276 @@ class ClineProviderClientTest {
 
         assertTrue(result is ProviderResult.Failure.NetworkError)
         assertTrue(result !is ProviderResult.Failure.AuthError, "500 should not be classified as AuthError")
+    }
+
+    // ===== ClinePass plan-usage-limits tests =====
+
+    @Test
+    fun `test fetchBalance populates ClinePass metadata when endpoint returns all three limits`() {
+        // 1. /me
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"id":"user-123","organizations":[]}}""")
+        )
+        // 2. /balance
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"balance": 1000000.0}}""")
+        )
+        // 3. /usages
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"items":[]}}""")
+        )
+        // 4. /plan/usage-limits
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """{"success":true,"data":{"limits":[
+                        {"type":"five_hour","percentUsed":79,"resetsAt":"2026-07-06T16:12:41Z"},
+                        {"type":"weekly","percentUsed":31,"resetsAt":"2026-07-13T11:12:41Z"},
+                        {"type":"monthly","percentUsed":15,"resetsAt":"2026-08-05T11:12:41Z"}
+                    ]}}"""
+                )
+        )
+
+        val account = Account(connectionType = ConnectionType.CLINE_API, authType = AuthType.CLINE_API_KEY)
+        val result = client.fetchBalance(account, "token")
+
+        assertTrue(result is ProviderResult.Success)
+        val success = result as ProviderResult.Success
+        val meta = success.snapshot.metadata
+        assertEquals("79", meta[ClineProviderClient.METADATA_FIVE_HOUR_USED])
+        assertEquals("31", meta[ClineProviderClient.METADATA_WEEKLY_USED])
+        assertEquals("15", meta[ClineProviderClient.METADATA_MONTHLY_USED])
+        assertEquals("2026-07-06T16:12:41Z", meta[ClineProviderClient.METADATA_FIVE_HOUR_RESETS_AT])
+        assertEquals("2026-07-13T11:12:41Z", meta[ClineProviderClient.METADATA_WEEKLY_RESETS_AT])
+        assertEquals("2026-08-05T11:12:41Z", meta[ClineProviderClient.METADATA_MONTHLY_RESETS_AT])
+    }
+
+    @Test
+    fun `test fetchBalance succeeds without ClinePass metadata when endpoint returns 500`() {
+        // 1. /me
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"id":"user-123","organizations":[]}}""")
+        )
+        // 2. /balance
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"balance": 5000000.0}}""")
+        )
+        // 3. /usages
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"items":[]}}""")
+        )
+        // 4. /plan/usage-limits returns 500
+        mockWebServer.enqueue(MockResponse().setResponseCode(500))
+
+        val account = Account(connectionType = ConnectionType.CLINE_API, authType = AuthType.CLINE_API_KEY)
+        val result = client.fetchBalance(account, "token")
+
+        assertTrue(result is ProviderResult.Success)
+        val success = result as ProviderResult.Success
+        assertTrue(success.snapshot.metadata.isEmpty(), "Metadata should be empty on plan-usage-limits failure")
+        assertEquals(0, BigDecimal("5.00").compareTo(success.snapshot.balance.credits?.remaining))
+    }
+
+    @Test
+    fun `test fetchBalance succeeds without ClinePass metadata when endpoint returns 404`() {
+        // 1. /me
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"id":"user-123","organizations":[]}}""")
+        )
+        // 2. /balance
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"balance": 5000000.0}}""")
+        )
+        // 3. /usages
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"items":[]}}""")
+        )
+        // 4. /plan/usage-limits returns 404
+        mockWebServer.enqueue(MockResponse().setResponseCode(404))
+
+        val account = Account(connectionType = ConnectionType.CLINE_API, authType = AuthType.CLINE_API_KEY)
+        val result = client.fetchBalance(account, "token")
+
+        assertTrue(result is ProviderResult.Success)
+        val success = result as ProviderResult.Success
+        assertTrue(success.snapshot.metadata.isEmpty())
+    }
+
+    @Test
+    fun `test fetchBalance produces no ClinePass metadata when response has success false`() {
+        // 1. /me
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"id":"user-123","organizations":[]}}""")
+        )
+        // 2. /balance
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"balance": 5000000.0}}""")
+        )
+        // 3. /usages
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"items":[]}}""")
+        )
+        // 4. /plan/usage-limits with success:false
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":false,"data":{}}""")
+        )
+
+        val account = Account(connectionType = ConnectionType.CLINE_API, authType = AuthType.CLINE_API_KEY)
+        val result = client.fetchBalance(account, "token")
+
+        assertTrue(result is ProviderResult.Success)
+        val success = result as ProviderResult.Success
+        assertTrue(success.snapshot.metadata.isEmpty())
+    }
+
+    @Test
+    fun `test fetchBalance produces no ClinePass metadata when limits array is empty`() {
+        // 1. /me
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"id":"user-123","organizations":[]}}""")
+        )
+        // 2. /balance
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"balance": 5000000.0}}""")
+        )
+        // 3. /usages
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"items":[]}}""")
+        )
+        // 4. /plan/usage-limits with empty limits
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"limits":[]}}""")
+        )
+
+        val account = Account(connectionType = ConnectionType.CLINE_API, authType = AuthType.CLINE_API_KEY)
+        val result = client.fetchBalance(account, "token")
+
+        assertTrue(result is ProviderResult.Success)
+        val success = result as ProviderResult.Success
+        assertTrue(success.snapshot.metadata.isEmpty())
+    }
+
+    @Test
+    fun `test fetchBalance ignores unknown limit types but keeps recognized ones`() {
+        // 1. /me
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"id":"user-123","organizations":[]}}""")
+        )
+        // 2. /balance
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"balance": 5000000.0}}""")
+        )
+        // 3. /usages
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"items":[]}}""")
+        )
+        // 4. /plan/usage-limits with mix of known/unknown types
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """{"success":true,"data":{"limits":[
+                        {"type":"five_hour","percentUsed":50,"resetsAt":"2026-07-06T16:12:41Z"},
+                        {"type":"daily","percentUsed":80,"resetsAt":"2026-07-07T00:00:00Z"},
+                        {"type":"weekly","percentUsed":25,"resetsAt":"2026-07-13T11:12:41Z"}
+                    ]}}"""
+                )
+        )
+
+        val account = Account(connectionType = ConnectionType.CLINE_API, authType = AuthType.CLINE_API_KEY)
+        val result = client.fetchBalance(account, "token")
+
+        assertTrue(result is ProviderResult.Success)
+        val success = result as ProviderResult.Success
+        val meta = success.snapshot.metadata
+        assertEquals("50", meta[ClineProviderClient.METADATA_FIVE_HOUR_USED])
+        assertEquals("25", meta[ClineProviderClient.METADATA_WEEKLY_USED])
+        assertFalse(meta.keys.any { it.contains("daily", ignoreCase = true) })
+        assertNull(meta["clinePassMonthlyUsed"])
+    }
+
+    @Test
+    fun `test fetchBalance clamps percentUsed to 0-100 range`() {
+        // 1. /me
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"id":"user-123","organizations":[]}}""")
+        )
+        // 2. /balance
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"balance": 1000000.0}}""")
+        )
+        // 3. /usages
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"success":true,"data":{"items":[]}}""")
+        )
+        // 4. /plan/usage-limits with out-of-range values
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """{"success":true,"data":{"limits":[
+                        {"type":"five_hour","percentUsed":150,"resetsAt":null},
+                        {"type":"weekly","percentUsed":-25,"resetsAt":""}
+                    ]}}"""
+                )
+        )
+
+        val account = Account(connectionType = ConnectionType.CLINE_API, authType = AuthType.CLINE_API_KEY)
+        val result = client.fetchBalance(account, "token")
+
+        assertTrue(result is ProviderResult.Success)
+        val success = result as ProviderResult.Success
+        val meta = success.snapshot.metadata
+        assertEquals("100", meta[ClineProviderClient.METADATA_FIVE_HOUR_USED])
+        assertEquals("0", meta[ClineProviderClient.METADATA_WEEKLY_USED])
+        assertNull(meta[ClineProviderClient.METADATA_FIVE_HOUR_RESETS_AT])
+        assertNull(meta[ClineProviderClient.METADATA_WEEKLY_RESETS_AT])
     }
 }

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/ui/ClinePassUsageRendererTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/ui/ClinePassUsageRendererTest.kt
@@ -1,0 +1,153 @@
+package org.zhavoronkov.tokenpulse.ui
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.zhavoronkov.tokenpulse.provider.cline.ClineProviderClient
+
+class ClinePassUsageRendererTest {
+
+    @Test
+    fun `hasUsage returns false for null metadata`() {
+        assertFalse(ClinePassUsageRenderer.hasUsage(null))
+    }
+
+    @Test
+    fun `hasUsage returns false for empty metadata`() {
+        assertFalse(ClinePassUsageRenderer.hasUsage(emptyMap()))
+    }
+
+    @Test
+    fun `hasUsage returns false for metadata with only reset keys`() {
+        val metadata = mapOf(
+            ClineProviderClient.METADATA_FIVE_HOUR_RESETS_AT to "2026-07-06T16:12:41Z"
+        )
+        assertFalse(ClinePassUsageRenderer.hasUsage(metadata))
+    }
+
+    @Test
+    fun `hasUsage returns false for metadata with unknown keys only`() {
+        val metadata = mapOf("someOtherKey" to "10")
+        assertFalse(ClinePassUsageRenderer.hasUsage(metadata))
+    }
+
+    @Test
+    fun `hasUsage returns false when used value is blank`() {
+        val metadata = mapOf(ClineProviderClient.METADATA_FIVE_HOUR_USED to "")
+        assertFalse(ClinePassUsageRenderer.hasUsage(metadata))
+    }
+
+    @Test
+    fun `hasUsage returns true for five-hour used value`() {
+        val metadata = mapOf(ClineProviderClient.METADATA_FIVE_HOUR_USED to "50")
+        assertTrue(ClinePassUsageRenderer.hasUsage(metadata))
+    }
+
+    @Test
+    fun `hasUsage returns true for weekly used value`() {
+        val metadata = mapOf(ClineProviderClient.METADATA_WEEKLY_USED to "30")
+        assertTrue(ClinePassUsageRenderer.hasUsage(metadata))
+    }
+
+    @Test
+    fun `hasUsage returns true for monthly used value`() {
+        val metadata = mapOf(ClineProviderClient.METADATA_MONTHLY_USED to "15")
+        assertTrue(ClinePassUsageRenderer.hasUsage(metadata))
+    }
+
+    @Test
+    fun `buildRows returns empty string for null metadata`() {
+        assertEquals("", ClinePassUsageRenderer.buildRows(null))
+    }
+
+    @Test
+    fun `buildRows returns empty string when no ClinePass usage available`() {
+        assertEquals("", ClinePassUsageRenderer.buildRows(emptyMap()))
+    }
+
+    @Test
+    fun `buildRows renders a ClinePass section header when usage is available`() {
+        val metadata = mapOf(ClineProviderClient.METADATA_FIVE_HOUR_USED to "10")
+        val html = ClinePassUsageRenderer.buildRows(metadata)
+
+        assertTrue(
+            html.contains("ClinePass"),
+            "Expected ClinePass section header in output, got: $html"
+        )
+        assertTrue(
+            html.contains("<b>ClinePass</b>"),
+            "Expected bold ClinePass header, got: $html"
+        )
+    }
+
+    @Test
+    fun `buildRows does not render a ClinePass section header when usage is absent`() {
+        assertFalse(ClinePassUsageRenderer.buildRows(emptyMap()).contains("ClinePass"))
+        assertFalse(ClinePassUsageRenderer.buildRows(null).contains("ClinePass"))
+    }
+
+    @Test
+    fun `buildRows renders 5-hour and weekly when only those keys exist`() {
+        val metadata = mapOf(
+            ClineProviderClient.METADATA_FIVE_HOUR_USED to "50",
+            ClineProviderClient.METADATA_WEEKLY_USED to "20"
+        )
+        val html = ClinePassUsageRenderer.buildRows(metadata)
+
+        assertTrue(html.contains("5-hour"), "Expected 5-hour row in output, got: $html")
+        assertTrue(html.contains("Weekly"), "Expected Weekly row in output, got: $html")
+        assertFalse(html.contains("Monthly"), "Did not expect Monthly row, got: $html")
+    }
+
+    @Test
+    fun `buildRows includes monthly row when monthly metadata exists`() {
+        val metadata = mapOf(
+            ClineProviderClient.METADATA_FIVE_HOUR_USED to "10",
+            ClineProviderClient.METADATA_WEEKLY_USED to "20",
+            ClineProviderClient.METADATA_MONTHLY_USED to "15"
+        )
+        val html = ClinePassUsageRenderer.buildRows(metadata)
+
+        assertTrue(html.contains("5-hour"), html)
+        assertTrue(html.contains("Weekly"), html)
+        assertTrue(html.contains("Monthly"), html)
+    }
+
+    @Test
+    fun `buildRows renders reset text only when reset timestamp present`() {
+        val withReset = mapOf(
+            ClineProviderClient.METADATA_FIVE_HOUR_USED to "50",
+            ClineProviderClient.METADATA_FIVE_HOUR_RESETS_AT to "2026-07-06T16:12:41Z"
+        )
+        val withoutReset = mapOf(
+            ClineProviderClient.METADATA_FIVE_HOUR_USED to "50"
+        )
+        assertTrue(ClinePassUsageRenderer.buildRows(withReset).contains("Resets:"))
+        assertFalse(ClinePassUsageRenderer.buildRows(withoutReset).contains("Resets:"))
+    }
+
+    @Test
+    fun `buildRows skips used key when value is not a valid number`() {
+        val metadata = mapOf(
+            ClineProviderClient.METADATA_FIVE_HOUR_USED to "not-a-number",
+            ClineProviderClient.METADATA_WEEKLY_USED to "20"
+        )
+        val html = ClinePassUsageRenderer.buildRows(metadata)
+
+        assertFalse(html.contains("5-hour"), "Invalid five-hour value must be skipped, got: $html")
+        assertTrue(html.contains("Weekly"), html)
+    }
+
+    @Test
+    fun `buildRows keeps a single ClinePass section header even when multiple limits present`() {
+        val metadata = mapOf(
+            ClineProviderClient.METADATA_FIVE_HOUR_USED to "10",
+            ClineProviderClient.METADATA_WEEKLY_USED to "20",
+            ClineProviderClient.METADATA_MONTHLY_USED to "15"
+        )
+        val html = ClinePassUsageRenderer.buildRows(metadata)
+        val headerCount = Regex("""<b>ClinePass</b>""").findAll(html).count()
+        assertEquals(1, headerCount, "Expected exactly one ClinePass section header, got: $html")
+    }
+}


### PR DESCRIPTION
## Summary
Adds optional **ClinePass usage-limit support** to the existing Cline API key integration. When Cline exposes plan usage data, the tooltip for `Cline: API Key` accounts now shows 5-hour, weekly, and monthly usage with reset timestamps. If no ClinePass data is available, the tooltip remains unchanged and only shows the normal balance rows.

This keeps ClinePass handling **tooltip-only** and **best-effort**, so undocumented endpoint failures never break the existing Cline balance integration.

## What changed
- **Provider (`ClineProviderClient`)** — added a best-effort fetch of `GET /api/v1/users/me/plan/usage-limits` after the existing balance call. Recognized remote `type` values (`five_hour`, `weekly`, `monthly`) are mapped to provider-specific metadata keys:
  - `clinePassFiveHourUsed`, `clinePassFiveHourResetsAt`
  - `clinePassWeeklyUsed`, `clinePassWeeklyResetsAt`
  - `clinePassMonthlyUsed`, `clinePassMonthlyResetsAt`

  `percentUsed` is clamped to `0..100` before storing, blank `resetsAt` values are omitted, unknown limit types are ignored, and any failure (non-2xx, malformed body, `success:false`, missing `data`, parse errors) is silently swallowed and produces an empty metadata map.

- **UI renderer (`ClinePassUsageRenderer`)** — new `object` that converts ClinePass metadata into tooltip rows via the existing `ProgressBarRenderer.buildUsageSection`. Returns an empty string when no recognized ClinePass usage is present, so the renderer is silent in the no-ClinePass case.

- **Status bar widget (`TokenPulseStatusBarWidget`)** — adds a `ConnectionType.CLINE_API` tooltip branch that always renders the existing Cline balance rows first and only appends the optional ClinePass block when `ClinePassUsageRenderer.hasUsage(metadata)` is true.

## Scope / non-goals
- Cline remains a **dollar-based provider** for status bar formatting, account table formatting, balance history behavior, and supported balance format settings.
- No config or dependency changes.
- No scraping or session capture — only authenticated API calls with the existing Cline API key.

## Validation
Targeted tests passed (`./gradlew test`):
- `ClinePassUsageRendererTest`
- `ClineProviderClientTest` (25 tests, including 7 new ClinePass cases)
- `StatusBarFormatterTest` (24 tests, unchanged)
- `ProgressBarRendererTest` (16 tests, unchanged)

Provider-test scenarios covered:
- successful response populates all six metadata keys
- endpoint failure (404/500) still returns `ProviderResult.Success` with existing balance data and no ClinePass metadata
- `success:false` or empty `limits` produces no metadata
- unknown limit types are ignored while recognized ones are preserved
- `percentUsed` is clamped to `0..100`

Renderer-test scenarios covered:
- `hasUsage` returns `false` for null/empty/unrecognized metadata
- `buildRows` returns an empty string when no ClinePass usage is available
- a single ClinePass section header is emitted when at least one limit is available
- 5-hour / Weekly / Monthly rows are emitted in the expected order
- `Resets: ...` lines are emitted only when a reset timestamp is present
- invalid numeric `used` values are silently skipped

## Files
- **Added**: `src/main/kotlin/org/zhavoronkov/tokenpulse/ui/ClinePassUsageRenderer.kt`, `src/test/kotlin/org/zhavoronkov/tokenpulse/ui/ClinePassUsageRendererTest.kt`
- **Modified**: `src/main/kotlin/org/zhavoronkov/tokenpulse/provider/cline/ClineProviderClient.kt`, `src/main/kotlin/org/zhavoronkov/tokenpulse/ui/TokenPulseStatusBarWidget.kt`, `src/test/kotlin/org/zhavoronkov/tokenpulse/provider/ClineProviderClientTest.kt`