### PR TITLE
fix: resolve NPE in CliConnectDialog due to constructor-time access of subclass state

### DIFF
--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/ClaudeConnectDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/ClaudeConnectDialog.kt
@@ -2,18 +2,22 @@ package org.zhavoronkov.tokenpulse.ui
 
 import org.zhavoronkov.tokenpulse.provider.anthropic.claudecode.ClaudeCliExecutor
 
-class ClaudeConnectDialog : CliConnectDialog() {
-
-    override val cliName = "Claude CLI"
-    override val installUrl = "https://docs.anthropic.com/en/docs/claude-code/getting-started"
-    override val headerHtml = "<html><b>Claude Code (Claude CLI)</b></html>"
-    override val descriptionHtml =
-        "<html>Claude Code uses the Claude CLI for authentication.<br>" +
-            "No API key required - the CLI handles login automatically.</html>"
-    override val requirementsHtml =
-        "<html>1. Install Claude CLI: <code>npm install -g @anthropic-ai/claude-code</code><br>" +
+class ClaudeConnectDialog : CliConnectDialog(
+    CliDialogSpec(
+        cliName = "Claude CLI",
+        installUrl = "https://docs.anthropic.com/en/docs/claude-code/getting-started",
+        headerHtml = "<html><b>Claude Code (Claude CLI)</b></html>",
+        descriptionHtml = "<html>Claude Code uses the Claude CLI for authentication.<br>" +
+            "No API key required - the CLI handles login automatically.</html>",
+        requirementsHtml = "<html>1. Install Claude CLI: <code>npm install -g @anthropic-ai/claude-code</code><br>" +
             "2. Run <code>claude</code> in terminal once to log in<br>" +
-            "3. The plugin will use CLI to fetch usage data</html>"
+            "3. The plugin will use CLI to fetch usage data</html>",
+    )
+) {
+
+    init {
+        startDetection()
+    }
 
     override fun performDetection(): DetectionResult {
         val available = ClaudeCliExecutor.isClaudeCliAvailable()

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/CliConnectDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/CliConnectDialog.kt
@@ -9,13 +9,21 @@ import java.awt.Font
 import javax.swing.JButton
 import javax.swing.JComponent
 
-abstract class CliConnectDialog : DialogWrapper(true) {
+/**
+ * Immutable specification for a CLI connect dialog.
+ * Passed via constructor to avoid reading open/abstract properties during base-class init.
+ */
+data class CliDialogSpec(
+    val cliName: String,
+    val installUrl: String,
+    val headerHtml: String,
+    val descriptionHtml: String,
+    val requirementsHtml: String,
+)
 
-    protected abstract val cliName: String
-    protected abstract val installUrl: String
-    protected abstract val headerHtml: String
-    protected abstract val descriptionHtml: String
-    protected abstract val requirementsHtml: String
+abstract class CliConnectDialog(
+    private val spec: CliDialogSpec,
+) : DialogWrapper(true) {
 
     var cliDetected: Boolean = false
         private set
@@ -39,25 +47,33 @@ abstract class CliConnectDialog : DialogWrapper(true) {
     }
 
     private val installButton = JButton("Installation Guide \u2192").apply {
-        addActionListener { BrowserUtil.browse(installUrl) }
+        addActionListener { BrowserUtil.browse(spec.installUrl) }
     }
 
     init {
-        title = "Connect $cliName"
+        title = "Connect ${spec.cliName}"
         setOKButtonText("Add Account")
         isOKActionEnabled = false
         init()
+        // Detection is NOT started here — subclass must call startDetection()
+        // after its own initialization is complete.
+    }
 
+    /**
+     * Kicks off CLI detection on a pooled thread.
+     * Must be called from the subclass [init] block (after super.init()).
+     */
+    protected fun startDetection() {
         detectCli()
     }
 
     override fun createCenterPanel(): JComponent = panel {
         row {
-            label(headerHtml)
+            label(spec.headerHtml)
         }
 
         row {
-            comment(descriptionHtml)
+            comment(spec.descriptionHtml)
         }
 
         separator()
@@ -78,7 +94,7 @@ abstract class CliConnectDialog : DialogWrapper(true) {
         }
 
         row {
-            comment(requirementsHtml)
+            comment(spec.requirementsHtml)
         }
 
         separator()
@@ -92,7 +108,7 @@ abstract class CliConnectDialog : DialogWrapper(true) {
     override fun getPreferredFocusedComponent() = detectButton
 
     private fun detectCli() {
-        statusLabel.text = "<html><i>Detecting $cliName...</i></html>"
+        statusLabel.text = "<html><i>Detecting ${spec.cliName}...</i></html>"
         versionLabel.text = ""
         isOKActionEnabled = false
         detectButton.isEnabled = false
@@ -102,19 +118,19 @@ abstract class CliConnectDialog : DialogWrapper(true) {
 
             ApplicationManager.getApplication().invokeLater {
                 if (!result.available) {
-                    statusLabel.text = "<html><font color='orange'><b>\u26a0 $cliName not found</b></font></html>"
+                    statusLabel.text = "<html><font color='orange'><b>\u26a0 ${spec.cliName} not found</b></font></html>"
                     versionLabel.text = "<html><font color='gray'>${result.errorMessage}</font></html>"
                     cliDetected = false
                     cliVersion = null
                 } else if (result.version != null) {
-                    statusLabel.text = "<html><font color='green'><b>\u2713 $cliName detected</b></font></html>"
+                    statusLabel.text = "<html><font color='green'><b>\u2713 ${spec.cliName} detected</b></font></html>"
                     versionLabel.text = "<html><font color='gray'>Version: ${result.version}</font></html>"
                     versionLabel.font = versionLabel.font.deriveFont(Font.PLAIN)
                     cliDetected = true
                     cliVersion = result.version
                     isOKActionEnabled = true
                 } else {
-                    statusLabel.text = "<html><font color='orange'><b>\u26a0 $cliName not found</b></font></html>"
+                    statusLabel.text = "<html><font color='orange'><b>\u26a0 ${spec.cliName} not found</b></font></html>"
                     versionLabel.text = "<html><font color='gray'>${result.errorMessage}</font></html>"
                     cliDetected = false
                     cliVersion = null

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/CliConnectDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/CliConnectDialog.kt
@@ -107,8 +107,27 @@ abstract class CliConnectDialog(
 
     override fun getPreferredFocusedComponent() = detectButton
 
+    // ── HTML helpers ────────────────────────────────────────────────────────
+
+    private fun detectingStatusHtml() =
+        "<html><i>Detecting ${spec.cliName}...</i></html>"
+
+    private fun notFoundStatusHtml() =
+        "<html><font color='orange'><b>\u26a0 ${spec.cliName} not found</b></font></html>"
+
+    private fun detectedStatusHtml() =
+        "<html><font color='green'><b>\u2713 ${spec.cliName} detected</b></font></html>"
+
+    private fun errorMessageHtml(msg: String) =
+        "<html><font color='gray'>$msg</font></html>"
+
+    private fun versionHtml(version: String) =
+        "<html><font color='gray'>Version: $version</font></html>"
+
+    // ── Detection ───────────────────────────────────────────────────────────
+
     private fun detectCli() {
-        statusLabel.text = "<html><i>Detecting ${spec.cliName}...</i></html>"
+        statusLabel.text = detectingStatusHtml()
         versionLabel.text = ""
         isOKActionEnabled = false
         detectButton.isEnabled = false
@@ -118,20 +137,20 @@ abstract class CliConnectDialog(
 
             ApplicationManager.getApplication().invokeLater {
                 if (!result.available) {
-                    statusLabel.text = "<html><font color='orange'><b>\u26a0 ${spec.cliName} not found</b></font></html>"
-                    versionLabel.text = "<html><font color='gray'>${result.errorMessage}</font></html>"
+                    statusLabel.text = notFoundStatusHtml()
+                    versionLabel.text = errorMessageHtml(result.errorMessage)
                     cliDetected = false
                     cliVersion = null
                 } else if (result.version != null) {
-                    statusLabel.text = "<html><font color='green'><b>\u2713 ${spec.cliName} detected</b></font></html>"
-                    versionLabel.text = "<html><font color='gray'>Version: ${result.version}</font></html>"
+                    statusLabel.text = detectedStatusHtml()
+                    versionLabel.text = versionHtml(result.version)
                     versionLabel.font = versionLabel.font.deriveFont(Font.PLAIN)
                     cliDetected = true
                     cliVersion = result.version
                     isOKActionEnabled = true
                 } else {
-                    statusLabel.text = "<html><font color='orange'><b>\u26a0 ${spec.cliName} not found</b></font></html>"
-                    versionLabel.text = "<html><font color='gray'>${result.errorMessage}</font></html>"
+                    statusLabel.text = notFoundStatusHtml()
+                    versionLabel.text = errorMessageHtml(result.errorMessage)
                     cliDetected = false
                     cliVersion = null
                 }

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/CodexConnectDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/CodexConnectDialog.kt
@@ -2,18 +2,22 @@ package org.zhavoronkov.tokenpulse.ui
 
 import org.zhavoronkov.tokenpulse.provider.openai.chatgpt.CodexCliExecutor
 
-class CodexConnectDialog : CliConnectDialog() {
-
-    override val cliName = "Codex CLI"
-    override val installUrl = "https://github.com/openai/codex"
-    override val headerHtml = "<html><b>Codex CLI (OpenAI Codex)</b></html>"
-    override val descriptionHtml =
-        "<html>Codex CLI uses the Codex CLI for authentication.<br>" +
-            "No API key required - the CLI handles login automatically.</html>"
-    override val requirementsHtml =
-        "<html>1. Install Codex CLI: <code>npm install -g @openai/codex</code><br>" +
+class CodexConnectDialog : CliConnectDialog(
+    CliDialogSpec(
+        cliName = "Codex CLI",
+        installUrl = "https://github.com/openai/codex",
+        headerHtml = "<html><b>Codex CLI (OpenAI Codex)</b></html>",
+        descriptionHtml = "<html>Codex CLI uses the Codex CLI for authentication.<br>" +
+            "No API key required - the CLI handles login automatically.</html>",
+        requirementsHtml = "<html>1. Install Codex CLI: <code>npm install -g @openai/codex</code><br>" +
             "2. Run <code>codex login</code> in terminal once to log in<br>" +
-            "3. The plugin will use CLI to fetch usage data</html>"
+            "3. The plugin will use CLI to fetch usage data</html>",
+    )
+) {
+
+    init {
+        startDetection()
+    }
 
     override fun performDetection(): DetectionResult {
         val available = CodexCliExecutor.isCodexCliAvailable()


### PR DESCRIPTION
## Root cause

The abstract class CliConnectDialog declared open/abstract properties (headerHtml, descriptionHtml, requirementsHtml) that were read during base-class init{}, before subclass field initializers had completed. In Kotlin/JVM this allows overridden non-null vals to be observed as null at construction time, causing a NullPointerException in RowImpl.label(text).

## Fix

1. CliConnectDialog.kt -- replaced abstract value properties with a constructor-parameter CliDialogSpec, eliminating constructor-time polymorphic access. Moved CLI detection start out of base init{} into a protected startDetection() method.
2. CodexConnectDialog.kt -- now passes its static config via super(CliDialogSpec(...)) and calls startDetection() from its own init{}.
3. ClaudeConnectDialog.kt -- same pattern.

## Validation

- ./gradlew compileKotlin -- BUILD SUCCESSFUL
- ./gradlew test -- BUILD SUCCESSFUL (all tests pass)
