### PR TITLE
feat(xiaomi): silent session refresh + unified provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ chain.crt
 private.pem
 private_encrypted.pem
 
+
+# Captured network traces (may contain session cookies/tokens)
+*.har

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `oauthAccount` (email • organization) on first successful refresh.
 
 ### Changed
+- **Unified Xiaomi MiMo provider** — the two previous connection types ("API (pay-as-you-go)"
+  and "Token Plan") are merged into a single **Xiaomi MiMo** account that tracks both the
+  pay-as-you-go dollar balance and the Token Plan Credits usage from the same captured
+  platform session. The status bar shows the dollar balance when present and falls back to
+  Token Plan usage otherwise; the tooltip shows both. Existing accounts are migrated on load
+  (both legacy types remap to the unified provider); duplicate accounts for the same Xiaomi
+  login are merged on first refresh.
 - **Progress-bar rendering** — the status-bar tooltip is now assembled as a Swing panel
   (`TokenPulseTooltipPanel` + `TooltipModel`) instead of generated HTML, and `ProgressBarRenderer`
   is now a theme-aware color helper (returns `JBColor`s rather than HTML strings).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
   - **ChatGPT (Codex CLI)** — CLI-based usage tracking via Codex CLI
   - **Nebius AI Studio** — Cookie-based auth with trial/paid balance
   - **Claude Code** — OAuth usage tracking that reads your existing `claude` login (multi-account)
-  - **Xiaomi MiMo** — API (pay-as-you-go) and Token Plan (subscription Credits)
+  - **Xiaomi MiMo** — Unified session tracking for both pay-as-you-go balance and Token Plan Credits
 - **🔄 Smart Refresh** — Configurable auto-refresh with TTL caching and single-flight coalescing to avoid rate limits.
 - **🔐 Secure Storage** — API keys are stored securely using IntelliJ's built-in `PasswordSafe`.
 - **📈 Dashboard Overview** — Detailed table view showing per-account provider, key preview, status, last refresh time, and credits.

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/model/ConnectionType.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/model/ConnectionType.kt
@@ -97,8 +97,23 @@ enum class ConnectionType(
     ),
 
     /**
-     * Xiaomi MiMo API - pay-as-you-go billing.
-     * Uses API key for chat completions, session capture for balance tracking.
+     * Xiaomi MiMo - unified provider.
+     *
+     * Tracks BOTH pay-as-you-go dollar balance and Token Plan Credits usage from
+     * the same captured Xiaomi platform session (no API key). This is the single
+     * user-selectable Xiaomi type; [XIAOMI_API] and [XIAOMI_TOKEN_PLAN] are
+     * retained only so legacy persisted accounts still deserialize.
+     */
+    XIAOMI(
+        provider = Provider.XIAOMI,
+        displayName = "MiMo",
+        description = "Tracks pay-as-you-go balance and Token Plan usage via your captured session.",
+        defaultAuthType = AuthType.XIAOMI_SESSION
+    ),
+
+    /**
+     * Legacy Xiaomi MiMo API (pay-as-you-go). Retained for deserialization of
+     * existing accounts only; migrated to [XIAOMI] on load. Not user-selectable.
      */
     XIAOMI_API(
         provider = Provider.XIAOMI,
@@ -108,8 +123,8 @@ enum class ConnectionType(
     ),
 
     /**
-     * Xiaomi MiMo Token Plan - subscription with Credits quota.
-     * Uses Token Plan API key, session capture for Credits usage tracking.
+     * Legacy Xiaomi MiMo Token Plan (subscription). Retained for deserialization
+     * of existing accounts only; migrated to [XIAOMI] on load. Not user-selectable.
      */
     XIAOMI_TOKEN_PLAN(
         provider = Provider.XIAOMI,
@@ -151,13 +166,21 @@ enum class ConnectionType(
             CLAUDE_CODE -> emptySet() // Uses metadata percentage, not dollar formats
             // Codex CLI uses percentage from metadata (not Credits)
             CODEX_CLI -> emptySet() // Uses metadata percentage, not dollar formats
-            // Xiaomi API has dollar balance, supports all formats
+            // Xiaomi (unified) has a dollar balance, supports all formats. When
+            // only Token Plan tokens are present, the formatter falls back to a
+            // percentage/credits display at render time.
+            XIAOMI -> setOf(
+                StatusBarDollarFormat.REMAINING_ONLY,
+                StatusBarDollarFormat.USED_OF_REMAINING,
+                StatusBarDollarFormat.PERCENTAGE_REMAINING
+            )
+            // Legacy Xiaomi API has dollar balance, supports all formats
             XIAOMI_API -> setOf(
                 StatusBarDollarFormat.REMAINING_ONLY,
                 StatusBarDollarFormat.USED_OF_REMAINING,
                 StatusBarDollarFormat.PERCENTAGE_REMAINING
             )
-            // Xiaomi Token Plan uses Credits (percentage-based)
+            // Legacy Xiaomi Token Plan uses Credits (percentage-based)
             XIAOMI_TOKEN_PLAN -> emptySet() // Uses Credits percentage, not dollar formats
         }
 
@@ -174,6 +197,7 @@ enum class ConnectionType(
     val isAvailable: Boolean
         get() = when (this) {
             OPENROUTER_PLUGIN -> false // Coming soon - requires OpenRouter plugin API exposure
+            XIAOMI_API, XIAOMI_TOKEN_PLAN -> false // Legacy: migrated to XIAOMI, kept only for deserialization
             else -> true
         }
 

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/ProviderRegistry.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/ProviderRegistry.kt
@@ -11,6 +11,8 @@ import org.zhavoronkov.tokenpulse.provider.openai.platform.OpenAiPlatformProvide
 import org.zhavoronkov.tokenpulse.provider.openrouter.OpenRouterPluginBridgeClient
 import org.zhavoronkov.tokenpulse.provider.openrouter.OpenRouterProviderClient
 import org.zhavoronkov.tokenpulse.provider.xiaomi.XiaomiProviderClient
+import org.zhavoronkov.tokenpulse.provider.xiaomi.XiaomiSessionRefresher
+import org.zhavoronkov.tokenpulse.settings.CredentialsStore
 
 /**
  * Registry for provider client instances.
@@ -31,7 +33,15 @@ interface ProviderRegistry {
  */
 class DefaultProviderRegistry(
     private val httpClient: OkHttpClient,
-    private val gson: Gson
+    private val gson: Gson,
+    /**
+     * Persists a rotated session secret back to storage. Defaults to the
+     * [CredentialsStore] app service; overridable in tests. Used by the Xiaomi
+     * client to save a silently-refreshed session (see [XiaomiSessionRefresher]).
+     */
+    private val sessionWriter: (accountId: String, newSecretJson: String) -> Unit = { id, json ->
+        CredentialsStore.getInstance().saveApiKey(id, json)
+    }
 ) : ProviderRegistry {
 
     private val openRouterClient by lazy { OpenRouterProviderClient(httpClient, gson) }
@@ -41,7 +51,14 @@ class DefaultProviderRegistry(
     private val openAiPlatformClient by lazy { OpenAiPlatformProviderClient(httpClient, gson) }
     private val codexClient by lazy { CodexProviderClient() }
     private val claudeCodeClient by lazy { ClaudeCodeProviderClient() }
-    private val xiaomiClient by lazy { XiaomiProviderClient(httpClient, gson) }
+    private val xiaomiClient by lazy {
+        XiaomiProviderClient(
+            httpClient = httpClient,
+            gson = gson,
+            refresher = XiaomiSessionRefresher(httpClient, gson),
+            sessionWriter = sessionWriter
+        )
+    }
 
     override fun getClient(connectionType: ConnectionType): ProviderClient {
         return when (connectionType) {

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/ProviderRegistry.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/ProviderRegistry.kt
@@ -69,7 +69,8 @@ class DefaultProviderRegistry(
             ConnectionType.OPENAI_PLATFORM -> openAiPlatformClient
             ConnectionType.CODEX_CLI -> codexClient
             ConnectionType.CLAUDE_CODE -> claudeCodeClient
-            ConnectionType.XIAOMI_API -> xiaomiClient
+            ConnectionType.XIAOMI,
+            ConnectionType.XIAOMI_API,
             ConnectionType.XIAOMI_TOKEN_PLAN -> xiaomiClient
         }
     }

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiProviderClient.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiProviderClient.kt
@@ -31,9 +31,16 @@ import org.zhavoronkov.tokenpulse.utils.TokenPulseLogger
  *   "serviceToken": "...",
  *   "userId": "...",
  *   "slh": "...",
- *   "ph": "..."
+ *   "ph": "...",
+ *   "passToken": "...",
+ *   "cUserId": "..."
  * }
  * ```
+ *
+ * The platform cookies (`serviceToken`/`slh`/`ph`) are short-lived (~1 day). The
+ * `passToken` (+ `userId`/`cUserId`) is the long-lived Xiaomi Passport credential
+ * on `account.xiaomi.com` that [XiaomiSessionRefresher] uses to silently mint a
+ * fresh platform session on expiry (see that class for the flow).
  *
  * ## Endpoints
  * - `GET /api/v1/balance` — Account balance (pay-as-you-go)
@@ -43,7 +50,9 @@ import org.zhavoronkov.tokenpulse.utils.TokenPulseLogger
 class XiaomiProviderClient(
     private val httpClient: OkHttpClient = OkHttpClient(),
     private val gson: Gson = Gson(),
-    private val baseUrl: String = XIAOMI_PLATFORM_URL
+    private val baseUrl: String = XIAOMI_PLATFORM_URL,
+    private val refresher: XiaomiSessionRefresher = XiaomiSessionRefresher(httpClient, gson, baseUrl),
+    private val sessionWriter: (accountId: String, newSecretJson: String) -> Unit = { _, _ -> }
 ) : ProviderClient {
 
     override fun fetchBalance(account: Account, secret: String): ProviderResult {
@@ -67,9 +76,7 @@ class XiaomiProviderClient(
 
     private fun fetchApiBalance(session: XiaomiSession, account: Account, traceId: String): ProviderResult {
         TokenPulseLogger.Provider.debug("[$traceId] Fetching Xiaomi API balance")
-        val request = buildRequest(session, "/api/v1/balance")
-
-        return executeRequest(request) { body ->
+        return executeRequest(session, account, "/api/v1/balance") { body ->
             val json = gson.fromJson(body, JsonObject::class.java)
             XiaomiResponseParser.parseApiBalance(json, account)
         }
@@ -81,9 +88,7 @@ class XiaomiProviderClient(
         traceId: String
     ): ProviderResult {
         TokenPulseLogger.Provider.debug("[$traceId] Fetching Xiaomi Token Plan usage")
-        val request = buildRequest(session, "/api/v1/tokenPlan/usage")
-
-        return executeRequest(request) { body ->
+        return executeRequest(session, account, "/api/v1/tokenPlan/usage") { body ->
             val json = gson.fromJson(body, JsonObject::class.java)
             XiaomiResponseParser.parseTokenPlanUsage(json, account)
         }
@@ -114,13 +119,51 @@ class XiaomiProviderClient(
             .build()
     }
 
-    private fun executeRequest(request: Request, parser: (String) -> ProviderResult): ProviderResult {
+    /**
+     * Execute [path] for [session], with a single silent-refresh retry on expiry.
+     *
+     * Expiry is detected as HTTP 401/403 OR a successful response whose body is HTML
+     * (a login page the shared client may have followed a redirect to) rather than
+     * the expected JSON. On expiry, if the session carries a `passToken`, we attempt
+     * [XiaomiSessionRefresher.refresh]; on success the new session is persisted via
+     * [sessionWriter] and the request is retried exactly once with the fresh cookies.
+     */
+    private fun executeRequest(
+        session: XiaomiSession,
+        account: Account,
+        path: String,
+        parser: (String) -> ProviderResult
+    ): ProviderResult {
+        val first = executeOnce(session, path, parser)
+        if (first !is ProviderResult.Failure.AuthError) {
+            return first
+        }
+
+        // Expired: attempt a one-shot silent re-login using the passport cookie.
+        val refreshed = refresher.refresh(session) ?: return first
+        sessionWriter(account.id, gson.toJson(refreshed))
+        TokenPulseLogger.Provider.debug("Xiaomi session refreshed for account=${account.id}, retrying $path")
+        return executeOnce(refreshed, path, parser)
+    }
+
+    private fun executeOnce(
+        session: XiaomiSession,
+        path: String,
+        parser: (String) -> ProviderResult
+    ): ProviderResult {
+        val request = buildRequest(session, path)
         return try {
             httpClient.newCall(request).execute().use { response ->
                 val body = response.body?.string().orEmpty()
 
                 if (!response.isSuccessful) {
                     return HttpErrorHandler.mapHttpError(response.code, "Xiaomi")
+                }
+
+                // A followed login-page redirect returns HTML with a 2xx status; treat
+                // it as an auth failure rather than letting it become a ParseError.
+                if (body.trimStart().startsWith("<")) {
+                    return ProviderResult.Failure.AuthError("Xiaomi session expired. Please reconnect.")
                 }
 
                 parser(body)
@@ -136,7 +179,9 @@ class XiaomiProviderClient(
         val serviceToken: String? = null,
         val userId: String? = null,
         val slh: String? = null,
-        val ph: String? = null
+        val ph: String? = null,
+        val passToken: String? = null,
+        val cUserId: String? = null
     )
 
     companion object {

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiProviderClient.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiProviderClient.kt
@@ -2,9 +2,10 @@ package org.zhavoronkov.tokenpulse.provider.xiaomi
 
 import com.google.gson.Gson
 import com.google.gson.JsonObject
-import com.google.gson.JsonSyntaxException
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import org.zhavoronkov.tokenpulse.model.Balance
+import org.zhavoronkov.tokenpulse.model.BalanceSnapshot
 import org.zhavoronkov.tokenpulse.model.ConnectionType
 import org.zhavoronkov.tokenpulse.model.ProviderResult
 import org.zhavoronkov.tokenpulse.provider.HttpErrorHandler
@@ -12,13 +13,16 @@ import org.zhavoronkov.tokenpulse.provider.ProviderClient
 import org.zhavoronkov.tokenpulse.provider.SessionParser
 import org.zhavoronkov.tokenpulse.settings.Account
 import org.zhavoronkov.tokenpulse.utils.TokenPulseLogger
+import java.time.Instant
 
 /**
  * Provider client for Xiaomi MiMo platform.
  *
- * Supports two connection types:
- * - [ConnectionType.XIAOMI_API]: Pay-as-you-go, balance in USD
- * - [ConnectionType.XIAOMI_TOKEN_PLAN]: Subscription with Credits quota
+ * Serves the unified [ConnectionType.XIAOMI] (and, transitionally, any legacy
+ * XIAOMI_API / XIAOMI_TOKEN_PLAN accounts not yet migrated). A single fetch
+ * queries BOTH the pay-as-you-go balance endpoint and the Token Plan usage
+ * endpoint and merges them into one snapshot carrying dollar credits and/or
+ * token credits.
  *
  * The Xiaomi API (`api.xiaomimimo.com`) is OpenAI-compatible for chat completions,
  * but has no balance/usage endpoints via API key. Balance is tracked via the
@@ -64,9 +68,13 @@ class XiaomiProviderClient(
                 "Invalid Xiaomi session. Please re-capture your session from platform.xiaomimimo.com"
             )
 
+        // Unified XIAOMI (and any not-yet-migrated legacy types) route through
+        // the merged path: query BOTH endpoints, share a single silent-refresh
+        // retry, compose one snapshot with whichever parts we got.
         return when (account.connectionType) {
-            ConnectionType.XIAOMI_API -> fetchApiBalance(session, account, traceId)
-            ConnectionType.XIAOMI_TOKEN_PLAN -> fetchTokenPlanUsage(session, account, traceId)
+            ConnectionType.XIAOMI,
+            ConnectionType.XIAOMI_API,
+            ConnectionType.XIAOMI_TOKEN_PLAN -> fetchMerged(session, account, traceId)
             else -> ProviderResult.Failure.AuthError("Unsupported connection type: ${account.connectionType}")
         }
     }
@@ -74,24 +82,123 @@ class XiaomiProviderClient(
     override fun testCredentials(account: Account, secret: String): ProviderResult =
         fetchBalance(account, secret)
 
-    private fun fetchApiBalance(session: XiaomiSession, account: Account, traceId: String): ProviderResult {
-        TokenPulseLogger.Provider.debug("[$traceId] Fetching Xiaomi API balance")
-        return executeRequest(session, account, "/api/v1/balance") { body ->
-            val json = gson.fromJson(body, JsonObject::class.java)
-            XiaomiResponseParser.parseApiBalance(json, account)
+    /**
+     * Query both `/api/v1/balance` (dollar) and `/api/v1/tokenPlan/usage`
+     * (Token Plan credits) and compose one [ProviderResult] carrying whichever
+     * parts we got.
+     *
+     * Auth-refresh policy (shared across both endpoints):
+     * - First pass: call both endpoints once with the current session.
+     * - If either came back as [ProviderResult.Failure.AuthError] AND the
+     *   session carries a `passToken`, attempt exactly ONE silent re-login via
+     *   [XiaomiSessionRefresher], persist the new session, then retry only the
+     *   endpoint(s) that failed with auth.
+     * - Compose: any successful endpoint contributes its slice
+     *   ([Credits] and/or [Tokens]) plus its metadata to a single
+     *   [BalanceSnapshot] stamped as [ConnectionType.XIAOMI].
+     *
+     * Failure semantics: return [ProviderResult.Failure.AuthError] only when
+     * BOTH endpoints failed with auth after the refresh attempt. If at least
+     * one endpoint succeeded, return [ProviderResult.Success] with the parts
+     * present — a non-auth failure of the other endpoint is silently dropped
+     * so we still surface the balance data we have. If both endpoints failed
+     * for non-auth reasons, propagate the first failure.
+     */
+    private fun fetchMerged(session: XiaomiSession, account: Account, traceId: String): ProviderResult {
+        TokenPulseLogger.Provider.debug("[$traceId] Xiaomi merged fetch (balance + tokenPlan)")
+
+        var balancePart = fetchPart(session, PATH_BALANCE, XiaomiResponseParser::parseApiBalance)
+        var tokenPart = fetchPart(session, PATH_TOKEN_PLAN, XiaomiResponseParser::parseTokenPlanUsage)
+
+        // Shared silent-refresh retry when either endpoint reported auth failure.
+        val balanceAuthFailed = balancePart is XiaomiResponseParser.BalancePart.Failure &&
+            balancePart.error is ProviderResult.Failure.AuthError
+        val tokenAuthFailed = tokenPart is XiaomiResponseParser.BalancePart.Failure &&
+            tokenPart.error is ProviderResult.Failure.AuthError
+
+        if (balanceAuthFailed || tokenAuthFailed) {
+            val refreshed = refresher.refresh(session)
+            if (refreshed != null) {
+                sessionWriter(account.id, gson.toJson(refreshed))
+                TokenPulseLogger.Provider.debug(
+                    "[$traceId] Xiaomi session refreshed for account=${account.id}; retrying failed endpoint(s)"
+                )
+                if (balanceAuthFailed) {
+                    balancePart = fetchPart(refreshed, PATH_BALANCE, XiaomiResponseParser::parseApiBalance)
+                }
+                if (tokenAuthFailed) {
+                    tokenPart = fetchPart(refreshed, PATH_TOKEN_PLAN, XiaomiResponseParser::parseTokenPlanUsage)
+                }
+            }
+        }
+
+        return composeSnapshot(account, balancePart, tokenPart)
+    }
+
+    /** Execute one endpoint and parse the body into a [XiaomiResponseParser.BalancePart]. */
+    private fun fetchPart(
+        session: XiaomiSession,
+        path: String,
+        parse: (JsonObject) -> XiaomiResponseParser.BalancePart
+    ): XiaomiResponseParser.BalancePart {
+        val request = buildRequest(session, path)
+        return try {
+            httpClient.newCall(request).execute().use { response ->
+                val body = response.body?.string().orEmpty()
+                if (!response.isSuccessful) {
+                    return XiaomiResponseParser.BalancePart.Failure(
+                        HttpErrorHandler.mapHttpError(response.code, "Xiaomi")
+                    )
+                }
+                // A followed login-page redirect returns HTML with a 2xx status;
+                // treat it as auth failure (same rule as the legacy path).
+                if (body.trimStart().startsWith("<")) {
+                    return XiaomiResponseParser.BalancePart.Failure(
+                        ProviderResult.Failure.AuthError("Xiaomi session expired. Please reconnect.")
+                    )
+                }
+                val json = gson.fromJson(body, JsonObject::class.java)
+                parse(json)
+            }
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            XiaomiResponseParser.BalancePart.Failure(
+                ProviderResult.Failure.NetworkError("Failed to connect to Xiaomi: ${e.message}")
+            )
         }
     }
 
-    private fun fetchTokenPlanUsage(
-        session: XiaomiSession,
+    private fun composeSnapshot(
         account: Account,
-        traceId: String
+        balancePart: XiaomiResponseParser.BalancePart,
+        tokenPart: XiaomiResponseParser.BalancePart
     ): ProviderResult {
-        TokenPulseLogger.Provider.debug("[$traceId] Fetching Xiaomi Token Plan usage")
-        return executeRequest(session, account, "/api/v1/tokenPlan/usage") { body ->
-            val json = gson.fromJson(body, JsonObject::class.java)
-            XiaomiResponseParser.parseTokenPlanUsage(json, account)
+        val credits = (balancePart as? XiaomiResponseParser.BalancePart.Credits)
+        val tokens = (tokenPart as? XiaomiResponseParser.BalancePart.TokensPart)
+
+        // Both failed: return AuthError if either was auth, else the first failure.
+        if (credits == null && tokens == null) {
+            val balanceFailure = (balancePart as XiaomiResponseParser.BalancePart.Failure).error
+            val tokenFailure = (tokenPart as XiaomiResponseParser.BalancePart.Failure).error
+            return when {
+                balanceFailure is ProviderResult.Failure.AuthError -> balanceFailure
+                tokenFailure is ProviderResult.Failure.AuthError -> tokenFailure
+                else -> balanceFailure
+            }
         }
+
+        val merged = mutableMapOf<String, String>()
+        credits?.metadata?.let { merged.putAll(it) }
+        tokens?.metadata?.let { merged.putAll(it) }
+
+        return ProviderResult.Success(
+            BalanceSnapshot(
+                accountId = account.id,
+                connectionType = ConnectionType.XIAOMI,
+                balance = Balance(credits = credits?.credits, tokens = tokens?.tokens),
+                timestamp = Instant.now(),
+                metadata = merged.toMap()
+            )
+        )
     }
 
     private fun parseSession(secret: String): XiaomiSession? =
@@ -119,62 +226,6 @@ class XiaomiProviderClient(
             .build()
     }
 
-    /**
-     * Execute [path] for [session], with a single silent-refresh retry on expiry.
-     *
-     * Expiry is detected as HTTP 401/403 OR a successful response whose body is HTML
-     * (a login page the shared client may have followed a redirect to) rather than
-     * the expected JSON. On expiry, if the session carries a `passToken`, we attempt
-     * [XiaomiSessionRefresher.refresh]; on success the new session is persisted via
-     * [sessionWriter] and the request is retried exactly once with the fresh cookies.
-     */
-    private fun executeRequest(
-        session: XiaomiSession,
-        account: Account,
-        path: String,
-        parser: (String) -> ProviderResult
-    ): ProviderResult {
-        val first = executeOnce(session, path, parser)
-        if (first !is ProviderResult.Failure.AuthError) {
-            return first
-        }
-
-        // Expired: attempt a one-shot silent re-login using the passport cookie.
-        val refreshed = refresher.refresh(session) ?: return first
-        sessionWriter(account.id, gson.toJson(refreshed))
-        TokenPulseLogger.Provider.debug("Xiaomi session refreshed for account=${account.id}, retrying $path")
-        return executeOnce(refreshed, path, parser)
-    }
-
-    private fun executeOnce(
-        session: XiaomiSession,
-        path: String,
-        parser: (String) -> ProviderResult
-    ): ProviderResult {
-        val request = buildRequest(session, path)
-        return try {
-            httpClient.newCall(request).execute().use { response ->
-                val body = response.body?.string().orEmpty()
-
-                if (!response.isSuccessful) {
-                    return HttpErrorHandler.mapHttpError(response.code, "Xiaomi")
-                }
-
-                // A followed login-page redirect returns HTML with a 2xx status; treat
-                // it as an auth failure rather than letting it become a ParseError.
-                if (body.trimStart().startsWith("<")) {
-                    return ProviderResult.Failure.AuthError("Xiaomi session expired. Please reconnect.")
-                }
-
-                parser(body)
-            }
-        } catch (e: JsonSyntaxException) {
-            ProviderResult.Failure.ParseError("Failed to parse Xiaomi response: ${e.message}")
-        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
-            ProviderResult.Failure.NetworkError("Failed to connect to Xiaomi: ${e.message}")
-        }
-    }
-
     data class XiaomiSession(
         val serviceToken: String? = null,
         val userId: String? = null,
@@ -186,5 +237,7 @@ class XiaomiProviderClient(
 
     companion object {
         const val XIAOMI_PLATFORM_URL = "https://platform.xiaomimimo.com"
+        private const val PATH_BALANCE = "/api/v1/balance"
+        private const val PATH_TOKEN_PLAN = "/api/v1/tokenPlan/usage"
     }
 }

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiResponseParser.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiResponseParser.kt
@@ -1,24 +1,38 @@
 package org.zhavoronkov.tokenpulse.provider.xiaomi
 
 import com.google.gson.JsonObject
-import org.zhavoronkov.tokenpulse.model.Balance
-import org.zhavoronkov.tokenpulse.model.BalanceSnapshot
-import org.zhavoronkov.tokenpulse.model.ConnectionType
 import org.zhavoronkov.tokenpulse.model.Credits
 import org.zhavoronkov.tokenpulse.model.ProviderResult
 import org.zhavoronkov.tokenpulse.model.Tokens
-import org.zhavoronkov.tokenpulse.settings.Account
 import java.math.BigDecimal
-import java.time.Instant
 
 /**
- * Parses Xiaomi platform API responses into [ProviderResult] domain objects.
+ * Parses Xiaomi platform API responses into partial balance parts that the
+ * client composes into a single [org.zhavoronkov.tokenpulse.model.BalanceSnapshot].
  *
- * Handles both the Xiaomi API balance endpoint and the Token Plan usage endpoint,
- * including safe null handling for stopped/expired plans where the API returns
+ * Each endpoint contributes ONE slice of the unified snapshot:
+ * - `/api/v1/balance` -> [BalancePart.Credits] (pay-as-you-go dollar amount)
+ * - `/api/v1/tokenPlan/usage` -> [BalancePart.TokensPart] (Token Plan quota)
+ *
+ * Envelope / auth errors are returned as [BalancePart.Failure] so the client
+ * can decide whether to trigger a shared silent-refresh retry.
+ *
+ * Handles safe null handling for stopped/expired plans where the API returns
  * `null` instead of expected objects or arrays.
  */
 internal object XiaomiResponseParser {
+
+    /**
+     * One endpoint's contribution to the unified Xiaomi snapshot.
+     * The client composes the successful parts and drops (or short-circuits on)
+     * the failures.
+     */
+    sealed class BalancePart {
+        data class Credits(val credits: org.zhavoronkov.tokenpulse.model.Credits, val metadata: Map<String, String>) :
+            BalancePart()
+        data class TokensPart(val tokens: Tokens, val metadata: Map<String, String>) : BalancePart()
+        data class Failure(val error: ProviderResult.Failure) : BalancePart()
+    }
 
     /**
      * Parse the Xiaomi API balance response (pay-as-you-go).
@@ -28,9 +42,9 @@ internal object XiaomiResponseParser {
      * { "code": 0, "data": { "balance": "55.48", "giftBalance": "55.48", "cashBalance": "0.00", "currency": "USD" } }
      * ```
      */
-    fun parseApiBalance(json: JsonObject, account: Account): ProviderResult {
+    fun parseApiBalance(json: JsonObject): BalancePart {
         val envelopeError = checkEnvelope(json)
-        if (envelopeError != null) return envelopeError
+        if (envelopeError != null) return BalancePart.Failure(envelopeError)
 
         val data = json.getObjectOrNull("data")
         val balance = data?.getStringOrNull("balance")?.toBigDecimalOrNull() ?: BigDecimal.ZERO
@@ -38,19 +52,12 @@ internal object XiaomiResponseParser {
         val cashBalance = data?.getStringOrNull("cashBalance")?.toBigDecimalOrNull() ?: BigDecimal.ZERO
         val currency = data?.getStringOrNull("currency") ?: "USD"
 
-        return ProviderResult.Success(
-            BalanceSnapshot(
-                accountId = account.id,
-                connectionType = ConnectionType.XIAOMI_API,
-                balance = Balance(
-                    credits = Credits(remaining = balance, total = null, used = null)
-                ),
-                timestamp = Instant.now(),
-                metadata = mapOf(
-                    "currency" to currency,
-                    "giftBalance" to giftBalance.toPlainString(),
-                    "cashBalance" to cashBalance.toPlainString()
-                )
+        return BalancePart.Credits(
+            credits = Credits(remaining = balance, total = null, used = null),
+            metadata = mapOf(
+                "currency" to currency,
+                "giftBalance" to giftBalance.toPlainString(),
+                "cashBalance" to cashBalance.toPlainString()
             )
         )
     }
@@ -66,9 +73,9 @@ internal object XiaomiResponseParser {
      * When a plan is stopped/expired, the API may return `null` for `data`,
      * `monthUsage`, or `items`. This method handles all such cases gracefully.
      */
-    fun parseTokenPlanUsage(json: JsonObject, account: Account): ProviderResult {
+    fun parseTokenPlanUsage(json: JsonObject): BalancePart {
         val envelopeError = checkEnvelope(json)
-        if (envelopeError != null) return envelopeError
+        if (envelopeError != null) return BalancePart.Failure(envelopeError)
 
         val data = json.getObjectOrNull("data")
         val monthUsage = data?.getObjectOrNull("monthUsage")
@@ -89,24 +96,17 @@ internal object XiaomiResponseParser {
 
         val planStatus = if (totalCredits == 0L) "inactive" else "active"
 
-        return ProviderResult.Success(
-            BalanceSnapshot(
-                accountId = account.id,
-                connectionType = ConnectionType.XIAOMI_TOKEN_PLAN,
-                balance = Balance(
-                    tokens = Tokens(
-                        used = usedCredits,
-                        total = totalCredits,
-                        remaining = totalCredits - usedCredits
-                    )
-                ),
-                timestamp = Instant.now(),
-                metadata = mapOf(
-                    "sessionUsed" to effectiveUsedPercent.toString(),
-                    "planUsed" to usedCredits.toString(),
-                    "planTotal" to totalCredits.toString(),
-                    "planStatus" to planStatus
-                )
+        return BalancePart.TokensPart(
+            tokens = Tokens(
+                used = usedCredits,
+                total = totalCredits,
+                remaining = totalCredits - usedCredits
+            ),
+            metadata = mapOf(
+                "sessionUsed" to effectiveUsedPercent.toString(),
+                "planUsed" to usedCredits.toString(),
+                "planTotal" to totalCredits.toString(),
+                "planStatus" to planStatus
             )
         )
     }

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiSessionRefresher.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiSessionRefresher.kt
@@ -1,0 +1,227 @@
+package org.zhavoronkov.tokenpulse.provider.xiaomi
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.zhavoronkov.tokenpulse.utils.TokenPulseLogger
+
+/**
+ * Performs a headless "silent re-login" for the Xiaomi MiMo platform, mirroring
+ * what the browser does when the short-lived platform session expires.
+ *
+ * ## Why this exists
+ * The cookies scoped to `platform.xiaomimimo.com` (`api-platform_serviceToken`,
+ * `api-platform_slh`, `api-platform_ph`) expire after ~1 day. The browser keeps
+ * working for days because it also holds a long-lived Xiaomi Passport cookie
+ * (`passToken`) on `account.xiaomi.com`. When the platform session dies, the SPA
+ * calls `genLoginUrl`, which 302s to `account.xiaomi.com/pass/serviceLogin`; the
+ * passport cookies silently mint a fresh platform session via the `/sts?sign=...`
+ * callback. This class reproduces that redirect chain with OkHttp.
+ *
+ * ## Flow
+ * 1. `GET {platform}/api/v1/genLoginUrl?currentPath=/console/balance` (no redirect
+ *    follow) -> read the `account.xiaomi.com/pass/serviceLogin?...` callback URL
+ *    (from the `Location` header on a 302, or a `location` field in a 200 body).
+ * 2. `GET {account}/pass/serviceLogin?...&_json=true` with the passport cookies ->
+ *    body is prefixed with `&&&START&&&`; the JSON must contain `location` (the
+ *    signed `/sts` callback) and `ssecurity` (proves silent SSO succeeded, i.e. no
+ *    captcha / password / 2FA needed).
+ * 3. `GET` the returned `location` (`{platform}/sts?sign=...`) -> the response
+ *    `Set-Cookie`s a fresh `api-platform_serviceToken` (+ `_slh`, `_ph`).
+ *
+ * Returns a new [XiaomiProviderClient.XiaomiSession] with the refreshed platform
+ * cookies and the preserved passport cookies, or `null` if the silent re-login
+ * could not complete (caller then surfaces an AuthError telling the user to
+ * reconnect).
+ *
+ * The absolute Xiaomi URLs returned by the redirect chain are re-hosted onto the
+ * injected [platformBaseUrl] / [accountBaseUrl] so the flow is testable against a
+ * single mock server while behaving identically in production.
+ */
+class XiaomiSessionRefresher(
+    private val httpClient: OkHttpClient,
+    private val gson: Gson = Gson(),
+    private val platformBaseUrl: String = XiaomiProviderClient.XIAOMI_PLATFORM_URL,
+    private val accountBaseUrl: String = XIAOMI_ACCOUNT_URL
+) {
+
+    /**
+     * Attempt a silent re-login. Requires [XiaomiProviderClient.XiaomiSession.passToken]
+     * and [XiaomiProviderClient.XiaomiSession.userId]; returns `null` otherwise.
+     */
+    fun refresh(session: XiaomiProviderClient.XiaomiSession): XiaomiProviderClient.XiaomiSession? {
+        if (session.passToken.isNullOrBlank() || session.userId.isNullOrBlank()) {
+            TokenPulseLogger.Provider.debug("Xiaomi refresh skipped: no passToken/userId captured")
+            return null
+        }
+
+        // A per-refresh client that does NOT auto-follow redirects, so we can drive
+        // the cross-host chain step by step. The shared client is left untouched.
+        val stepClient = httpClient.newBuilder()
+            .followRedirects(false)
+            .followSslRedirects(false)
+            .build()
+
+        return try {
+            val serviceLoginUrl = fetchServiceLoginUrl(stepClient, session) ?: return null
+            val stsUrl = fetchStsCallbackUrl(stepClient, serviceLoginUrl, session) ?: return null
+            val platformCookies = harvestPlatformCookies(stepClient, stsUrl, session) ?: return null
+            session.copy(
+                serviceToken = platformCookies.serviceToken,
+                slh = platformCookies.slh ?: session.slh,
+                ph = platformCookies.ph ?: session.ph
+            )
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            TokenPulseLogger.Provider.warn("Xiaomi silent refresh failed: ${e.message}")
+            null
+        }
+    }
+
+    /** Step 1: call genLoginUrl and extract the account.xiaomi.com serviceLogin callback URL. */
+    private fun fetchServiceLoginUrl(
+        client: OkHttpClient,
+        session: XiaomiProviderClient.XiaomiSession
+    ): HttpUrl? {
+        val request = Request.Builder()
+            .url("$platformBaseUrl/api/v1/genLoginUrl?currentPath=%2Fconsole%2Fbalance")
+            .header("Accept", "*/*")
+            .header("Cookie", platformCookieHeader(session))
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            val location = response.header("Location")
+                ?: extractJsonField(response.body?.string().orEmpty(), "location")
+                ?: return null
+            return rehost(location, accountBaseUrl)
+        }
+    }
+
+    /** Step 2: call serviceLogin with the passport cookies and extract the signed /sts callback. */
+    private fun fetchStsCallbackUrl(
+        client: OkHttpClient,
+        serviceLoginUrl: HttpUrl,
+        session: XiaomiProviderClient.XiaomiSession
+    ): HttpUrl? {
+        val jsonUrl = serviceLoginUrl.newBuilder().setQueryParameter("_json", "true").build()
+        val request = Request.Builder()
+            .url(jsonUrl)
+            .header("Accept", "*/*")
+            .header("Cookie", passportCookieHeader(session))
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            val json = parsePassportJson(response.body?.string().orEmpty()) ?: return null
+            // ssecurity present => already authenticated silently (no captcha/2FA).
+            if (getString(json, "ssecurity").isNullOrBlank()) {
+                TokenPulseLogger.Provider.debug("Xiaomi refresh: passport not silently authenticated (no ssecurity)")
+                return null
+            }
+            val location = getString(json, "location") ?: return null
+            return rehost(location, platformBaseUrl)
+        }
+    }
+
+    /** Step 3: GET the /sts callback and harvest the fresh platform Set-Cookie values. */
+    private fun harvestPlatformCookies(
+        client: OkHttpClient,
+        stsUrl: HttpUrl,
+        session: XiaomiProviderClient.XiaomiSession
+    ): PlatformCookies? {
+        val request = Request.Builder()
+            .url(stsUrl)
+            .header("Accept", "*/*")
+            .header("Cookie", passportCookieHeader(session))
+            .build()
+
+        client.newCall(request).execute().use { response ->
+            val setCookies = response.headers("Set-Cookie")
+            val serviceToken = cookieValue(setCookies, "api-platform_serviceToken") ?: return null
+            return PlatformCookies(
+                serviceToken = serviceToken,
+                slh = cookieValue(setCookies, "api-platform_slh"),
+                ph = cookieValue(setCookies, "api-platform_ph")
+            )
+        }
+    }
+
+    private fun platformCookieHeader(session: XiaomiProviderClient.XiaomiSession): String {
+        val parts = mutableListOf<String>()
+        session.serviceToken?.let { parts.add("api-platform_serviceToken=\"$it\"") }
+        session.userId?.let { parts.add("userId=$it") }
+        session.slh?.let { parts.add("api-platform_slh=\"$it\"") }
+        session.ph?.let { parts.add("api-platform_ph=\"$it\"") }
+        return parts.joinToString("; ")
+    }
+
+    private fun passportCookieHeader(session: XiaomiProviderClient.XiaomiSession): String {
+        val parts = mutableListOf<String>()
+        session.passToken?.let { parts.add("passToken=$it") }
+        session.userId?.let { parts.add("userId=$it") }
+        session.cUserId?.let { parts.add("cUserId=$it") }
+        return parts.joinToString("; ")
+    }
+
+    /**
+     * Re-host an absolute Xiaomi URL onto an injected base URL, preserving path and
+     * query. This keeps production behavior (real Xiaomi hosts) while letting tests
+     * route the whole chain through one mock server.
+     */
+    private fun rehost(rawUrl: String, base: String): HttpUrl? {
+        val target = rawUrl.toHttpUrlOrNull() ?: return null
+        val baseUrl = base.toHttpUrlOrNull() ?: return null
+        return baseUrl.newBuilder()
+            .encodedPath(target.encodedPath)
+            .encodedQuery(target.encodedQuery)
+            .build()
+    }
+
+    /** Strip the `&&&START&&&` prefix Xiaomi Passport prepends, then parse JSON. */
+    private fun parsePassportJson(body: String): JsonObject? {
+        val trimmed = body.trim().removePrefix(PASSPORT_JSON_PREFIX).trim()
+        if (trimmed.isEmpty() || !trimmed.startsWith("{")) return null
+        return try {
+            gson.fromJson(trimmed, JsonObject::class.java)
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            null
+        }
+    }
+
+    private fun extractJsonField(body: String, field: String): String? {
+        val json = try {
+            gson.fromJson(body, JsonObject::class.java)
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            return null
+        }
+        return getString(json, field)
+    }
+
+    private fun getString(json: JsonObject?, field: String): String? {
+        val element = json?.get(field) ?: return null
+        return if (element.isJsonPrimitive) element.asString else null
+    }
+
+    private fun cookieValue(setCookies: List<String>, name: String): String? {
+        val prefix = "$name="
+        for (header in setCookies) {
+            val first = header.substringBefore(';').trim()
+            if (first.startsWith(prefix)) {
+                return first.substring(prefix.length).removeSurrounding("\"")
+            }
+        }
+        return null
+    }
+
+    private data class PlatformCookies(
+        val serviceToken: String,
+        val slh: String?,
+        val ph: String?
+    )
+
+    companion object {
+        const val XIAOMI_ACCOUNT_URL = "https://account.xiaomi.com"
+        private const val PASSPORT_JSON_PREFIX = "&&&START&&&"
+    }
+}

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/service/BalanceRefreshService.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/service/BalanceRefreshService.kt
@@ -13,7 +13,11 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import org.zhavoronkov.tokenpulse.model.ConnectionType
 import org.zhavoronkov.tokenpulse.model.ProviderResult
+import org.zhavoronkov.tokenpulse.provider.SessionParser
+import org.zhavoronkov.tokenpulse.provider.xiaomi.XiaomiProviderClient
+import org.zhavoronkov.tokenpulse.settings.Account
 import org.zhavoronkov.tokenpulse.settings.AuthType
 import org.zhavoronkov.tokenpulse.settings.CredentialsStore
 import org.zhavoronkov.tokenpulse.settings.TokenPulseSettingsService
@@ -56,7 +60,14 @@ class BalanceRefreshService : Disposable {
     private val notificationThrottleMs = Constants.NOTIFICATION_THROTTLE_MS
 
     init {
-        startAutoRefresh()
+        // One-time migration for the Xiaomi provider unification: merge duplicate
+        // Xiaomi accounts (same userId). Runs off-EDT on the IO scope because it
+        // reads session secrets from PasswordSafe, and completes BEFORE the first
+        // refresh so a removed duplicate never gets refreshed.
+        scope.launch {
+            dedupeXiaomiAccounts()
+            startAutoRefresh()
+        }
     }
 
     fun restartAutoRefresh() {
@@ -209,6 +220,75 @@ class BalanceRefreshService : Disposable {
         scope.cancel()
     }
 
+    /**
+     * One-time migration: collapse duplicate unified-Xiaomi accounts that share
+     * the same Xiaomi `userId` into a single account.
+     *
+     * Before this session-unification work, a user could add both a
+     * pay-as-you-go and a Token Plan account for the SAME Xiaomi login. Post
+     * migration both are [ConnectionType.XIAOMI] and each shows both balances,
+     * so the second is redundant. We keep one survivor per userId and remove the
+     * rest (account + PasswordSafe secret).
+     *
+     * Safety:
+     * - Runs at most once, guarded by [TokenPulseSettings.xiaomiDedupeDone].
+     * - Reads secrets on the IO scope (never the EDT).
+     * - DATA-LOSS GUARD: any account whose secret is missing/unparseable or
+     *   whose userId is blank is left untouched and never merged.
+     * - Survivor preference: an account whose session carries a `passToken`
+     *   (silent-refresh capable) wins; ties break by lowest id for determinism.
+     */
+    private fun dedupeXiaomiAccounts() {
+        val settingsService = TokenPulseSettingsService.getInstance()
+        if (settingsService.state.xiaomiDedupeDone) return
+
+        val credentials = CredentialsStore.getInstance()
+        val accounts = settingsService.state.accounts
+        val xiaomiAccounts = accounts.filter { it.connectionType == ConnectionType.XIAOMI }
+
+        // Group by userId; only accounts with a readable, parseable session that
+        // yields a non-blank userId are eligible for merging.
+        val byUserId = xiaomiAccounts
+            .mapNotNull { account ->
+                val session = credentials.getApiKey(account.id)?.let { parseXiaomiSession(it) }
+                val userId = session?.userId?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                Triple(account, userId, session)
+            }
+            .groupBy { it.second }
+
+        val idsToRemove = mutableListOf<String>()
+        byUserId.values.filter { it.size > 1 }.forEach { group ->
+            val sorted = group.sortedWith(
+                compareByDescending<Triple<Account, String, XiaomiProviderClient.XiaomiSession>> {
+                    !it.third.passToken.isNullOrBlank()
+                }.thenBy { it.first.id }
+            )
+            // Keep the first (survivor); mark the rest for removal.
+            sorted.drop(1).forEach { idsToRemove.add(it.first.id) }
+        }
+
+        if (idsToRemove.isEmpty()) {
+            settingsService.state.xiaomiDedupeDone = true
+            return
+        }
+
+        TokenPulseLogger.Service.info("Xiaomi dedup: merging ${idsToRemove.size} duplicate account(s)")
+        idsToRemove.forEach { credentials.removeApiKey(it) }
+        settingsService.state.accounts = accounts.filter { it.id !in idsToRemove }
+        settingsService.state.xiaomiDedupeDone = true
+
+        refreshAll(force = true)
+    }
+
+    private fun parseXiaomiSession(secret: String): XiaomiProviderClient.XiaomiSession? =
+        SessionParser.parse(
+            secret = secret,
+            sessionClass = XiaomiProviderClient.XiaomiSession::class.java,
+            validator = { !it.serviceToken.isNullOrBlank() },
+            providerName = "Xiaomi",
+            gson = com.google.gson.Gson()
+        )
+
     private fun startAutoRefresh() {
         restartAutoRefresh()
     }
@@ -259,5 +339,6 @@ internal fun isApiKeyAuth(authType: AuthType): Boolean = when (authType) {
     AuthType.CODEX_CLI_LOCAL,
     AuthType.OPENAI_OAUTH,
     AuthType.NEBIUS_BILLING_SESSION,
+    AuthType.XIAOMI_SESSION,
     AuthType.OPENROUTER_PLUGIN_BRIDGE -> false
 }

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/settings/Account.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/settings/Account.kt
@@ -60,7 +60,17 @@ enum class AuthType(val displayName: String) {
      * The stored secret is a raw API key string (e.g., "tp-...").
      * Credits usage is tracked via Xiaomi platform session capture.
      */
-    XIAOMI_TOKEN_PLAN_KEY("Token Plan Key")
+    XIAOMI_TOKEN_PLAN_KEY("Token Plan Key"),
+
+    /**
+     * Xiaomi MiMo unified session.
+     *
+     * The stored secret is the captured platform session JSON (serviceToken +
+     * passport cookies). Used by the single [ConnectionType.XIAOMI] which reads
+     * both pay-as-you-go balance and Token Plan usage from the same session.
+     * No API key is involved (the sk-/tp- keys were inference-only).
+     */
+    XIAOMI_SESSION("Session")
 }
 
 /**
@@ -164,9 +174,18 @@ fun List<Account>.normalizeConnectionAuthTypes(): List<Account> = map { account 
  * Returns a sanitized list with all accounts having valid, consistent values.
  */
 fun List<Account>.sanitizeAccounts(): List<Account> = map { account ->
+    // Migration: fold legacy Xiaomi split providers into the unified XIAOMI.
+    // Both legacy names shared a session, so the stored secret is already the
+    // unified session JSON keyed by account.id — nothing to rewrite in
+    // PasswordSafe here.
+    val remappedConnectionType = when (account.connectionType) {
+        ConnectionType.XIAOMI_API, ConnectionType.XIAOMI_TOKEN_PLAN -> ConnectionType.XIAOMI
+        else -> account.connectionType
+    }
+
     // Validate connectionType - default to CLINE_API if invalid/missing
     val validConnectionType = try {
-        ConnectionType.entries.find { it == account.connectionType } ?: ConnectionType.CLINE_API
+        ConnectionType.entries.find { it == remappedConnectionType } ?: ConnectionType.CLINE_API
     } catch (_: Exception) {
         ConnectionType.CLINE_API
     }

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/settings/TokenPulseSettings.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/settings/TokenPulseSettings.kt
@@ -48,6 +48,13 @@ data class TokenPulseSettings(
     var hasSeenWelcome: Boolean = false,
     var lastSeenVersion: String = "",
 
+    /**
+     * One-time guard for the Xiaomi provider-unification dedup migration.
+     * Set true after duplicate Xiaomi accounts (same userId) are merged so the
+     * migration runs at most once. See BalanceRefreshService.dedupeXiaomiAccounts.
+     */
+    var xiaomiDedupeDone: Boolean = false,
+
     // Status bar display settings
     /** Determines what data is shown in the status bar. */
     var statusBarDisplayMode: StatusBarDisplayMode = StatusBarDisplayMode.AUTO,

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/AccountEditDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/AccountEditDialog.kt
@@ -61,13 +61,20 @@ class AccountEditDialog(
 ) : DialogWrapper(true) {
 
     companion object {
-        private val XIAOMI_TYPES = setOf(ConnectionType.XIAOMI_API, ConnectionType.XIAOMI_TOKEN_PLAN)
+        // Unified XIAOMI plus the retained legacy types (a persisted account may
+        // still be legacy until the startup migration/dedup runs).
+        private val XIAOMI_TYPES = setOf(
+            ConnectionType.XIAOMI,
+            ConnectionType.XIAOMI_API,
+            ConnectionType.XIAOMI_TOKEN_PLAN
+        )
         private val SESSION_BASED_TYPES = setOf(
             ConnectionType.NEBIUS_BILLING,
             ConnectionType.OPENAI_PLATFORM,
             ConnectionType.CODEX_CLI,
             ConnectionType.CLAUDE_CODE,
             ConnectionType.OPENROUTER_PLUGIN,
+            ConnectionType.XIAOMI,
             ConnectionType.XIAOMI_API,
             ConnectionType.XIAOMI_TOKEN_PLAN
         )
@@ -236,9 +243,7 @@ class AccountEditDialog(
 
     /** Holds the captured Xiaomi session JSON. */
     private var capturedXiaomiSession: String? =
-        if (account?.connectionType == ConnectionType.XIAOMI_API ||
-            account?.connectionType == ConnectionType.XIAOMI_TOKEN_PLAN
-        ) {
+        if (account?.connectionType in XIAOMI_TYPES) {
             existingSecret
         } else {
             null
@@ -315,7 +320,9 @@ class AccountEditDialog(
         ConnectionType.CODEX_CLI -> capturedCodexSecret ?: ""
         ConnectionType.NEBIUS_BILLING -> capturedNebiusSession ?: ""
         ConnectionType.OPENAI_PLATFORM -> capturedOpenAiSecret ?: ""
-        ConnectionType.XIAOMI_API, ConnectionType.XIAOMI_TOKEN_PLAN -> capturedXiaomiSession ?: ""
+        ConnectionType.XIAOMI,
+        ConnectionType.XIAOMI_API,
+        ConnectionType.XIAOMI_TOKEN_PLAN -> capturedXiaomiSession ?: ""
         else -> String(keyField.password).trim()
     }
 
@@ -346,6 +353,7 @@ class AccountEditDialog(
         ConnectionType.NEBIUS_BILLING -> "https://tokenfactory.nebius.com/"
         ConnectionType.OPENAI_PLATFORM -> "https://platform.openai.com/settings/organization/admin-keys"
         ConnectionType.CODEX_CLI -> "https://github.com/openai/codex"
+        ConnectionType.XIAOMI,
         ConnectionType.XIAOMI_API,
         ConnectionType.XIAOMI_TOKEN_PLAN -> "https://platform.xiaomimimo.com/console/api-keys"
     }
@@ -526,12 +534,11 @@ class AccountEditDialog(
                 "Install via: npm install -g @openai/codex"
         ConnectionType.OPENAI_PLATFORM ->
             "OpenAI API key. Click \"Connect API Key →\" to capture your key."
-        ConnectionType.XIAOMI_API ->
-            "Xiaomi MiMo pay-as-you-go API. Click \"Connect Xiaomi Account →\" to capture your platform session. " +
-                "Get your API key at platform.xiaomimimo.com."
+        ConnectionType.XIAOMI,
+        ConnectionType.XIAOMI_API,
         ConnectionType.XIAOMI_TOKEN_PLAN ->
-            "Xiaomi MiMo Token Plan. Click \"Connect Xiaomi Account →\" to capture your platform session. " +
-                "Subscribe at platform.xiaomimimo.com/token-plan."
+            "Xiaomi MiMo. Click \"Connect Xiaomi Account →\" to sign in and capture your platform session. " +
+                "Tracks both pay-as-you-go balance and Token Plan usage."
     }
 
     // ── Panel construction ─────────────────────────────────────────────────
@@ -672,7 +679,9 @@ class AccountEditDialog(
             ConnectionType.OPENAI_PLATFORM -> validateOpenAi()
             ConnectionType.CODEX_CLI -> validateCodex()
             ConnectionType.CLAUDE_CODE -> validateClaudeCode()
-            ConnectionType.XIAOMI_API, ConnectionType.XIAOMI_TOKEN_PLAN -> validateXiaomi()
+            ConnectionType.XIAOMI,
+            ConnectionType.XIAOMI_API,
+            ConnectionType.XIAOMI_TOKEN_PLAN -> validateXiaomi()
             else -> validateOther()
         }
     }

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/BalanceFormatter.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/BalanceFormatter.kt
@@ -20,8 +20,7 @@ object BalanceFormatter {
     /** Connection types that report usage as percentage (not dollars). */
     private val usagePercentageTypes = setOf(
         ConnectionType.CLAUDE_CODE,
-        ConnectionType.CODEX_CLI,
-        ConnectionType.XIAOMI_TOKEN_PLAN
+        ConnectionType.CODEX_CLI
     )
 
     /**
@@ -49,8 +48,8 @@ object BalanceFormatter {
     ): String {
         val connectionType = result.snapshot.connectionType
 
-        // For XIAOMI_TOKEN_PLAN with non-percentage format, show credits data
-        if (connectionType == ConnectionType.XIAOMI_TOKEN_PLAN && dollarFormat != null &&
+        // For XIAOMI with a non-percentage dollar format, show Token Plan credits data
+        if (connectionType == ConnectionType.XIAOMI && dollarFormat != null &&
             dollarFormat != StatusBarDollarFormat.PERCENTAGE_REMAINING
         ) {
             return formatXiaomiTokenPlanCredits(result, format, provider, dollarFormat)
@@ -125,7 +124,7 @@ object BalanceFormatter {
                 val weekly = metadata["weeklyUsed"]?.toFloatOrNull()?.toInt()
                 UsageData(fiveHour, weekly, "5h", "wk")
             }
-            ConnectionType.XIAOMI_TOKEN_PLAN -> {
+            ConnectionType.XIAOMI -> {
                 val used = metadata["sessionUsed"]?.toIntOrNull()
                 UsageData(used, null, "Credits", "")
             }
@@ -462,6 +461,17 @@ object BalanceFormatter {
         // Check for usage-percentage type first
         if (isUsagePercentageType(connectionType)) {
             return StatusBarData.UsagePercentage(provider)
+        }
+
+        // Xiaomi (unified): prefer the pay-as-you-go dollar balance; when there
+        // is none, fall back to the Token Plan usage percentage/credits.
+        if (connectionType == ConnectionType.XIAOMI) {
+            val credits = snapshot.balance.credits
+            return when {
+                credits?.remaining != null -> StatusBarData.RemainingDollars(credits.remaining, provider)
+                snapshot.balance.tokens != null -> StatusBarData.UsagePercentage(provider)
+                else -> StatusBarData.NoData
+            }
         }
 
         // Check for dollar amounts

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/TooltipModel.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/TooltipModel.kt
@@ -1,11 +1,11 @@
 package org.zhavoronkov.tokenpulse.ui
 
+import org.zhavoronkov.tokenpulse.model.Balance
 import org.zhavoronkov.tokenpulse.model.ConnectionType
 import org.zhavoronkov.tokenpulse.model.Credits
 import org.zhavoronkov.tokenpulse.model.NebiusBalanceBreakdown
 import org.zhavoronkov.tokenpulse.model.Provider
 import org.zhavoronkov.tokenpulse.model.ProviderResult
-import org.zhavoronkov.tokenpulse.model.Tokens
 import org.zhavoronkov.tokenpulse.settings.Account
 import org.zhavoronkov.tokenpulse.utils.ResetTimeFormatter
 import java.math.BigDecimal
@@ -77,8 +77,8 @@ internal object TooltipModel {
                         appendCodexRows(rows, snapshot.metadata)
                     snapshot.connectionType == ConnectionType.CLAUDE_CODE ->
                         appendClaudeCodeRows(rows, snapshot.metadata)
-                    snapshot.connectionType == ConnectionType.XIAOMI_TOKEN_PLAN ->
-                        appendXiaomiTokenPlanRows(rows, snapshot.metadata, snapshot.balance.tokens)
+                    snapshot.connectionType == ConnectionType.XIAOMI ->
+                        appendXiaomiRows(rows, snapshot.metadata, snapshot.balance)
                     snapshot.connectionType == ConnectionType.CLINE_API ->
                         appendClineRows(rows, snapshot.balance.credits, snapshot.metadata)
                     else ->
@@ -241,15 +241,34 @@ internal object TooltipModel {
     private fun resetInline(iso: String?): String? =
         ResetTimeFormatter.formatReset(iso)?.let { "Resets $it" }
 
-    private fun appendXiaomiTokenPlanRows(
+    /**
+     * Unified Xiaomi tooltip: shows the pay-as-you-go dollar balance AND the
+     * Token Plan usage, rendering whichever parts are present. When a Xiaomi
+     * login has both, both blocks appear; when it has only one, only that block
+     * appears.
+     */
+    private fun appendXiaomiRows(
         rows: MutableList<TooltipRow>,
         metadata: Map<String, String>?,
-        tokens: Tokens?
+        balance: Balance
     ) {
-        if (metadata == null && tokens == null) {
+        val credits = balance.credits
+        val tokens = balance.tokens
+        val hasDollar = credits?.remaining != null
+        val hasTokenPlan = metadata?.get("sessionUsed")?.toIntOrNull() != null ||
+            (tokens?.total != null && tokens.total > 0)
+
+        if (!hasDollar && !hasTokenPlan) {
             rows.add(TooltipRow.Info("No usage data"))
             return
         }
+
+        // Pay-as-you-go dollar balance block.
+        if (hasDollar) {
+            rows.add(TooltipRow.LabelValue("Balance:", formatAmount(credits!!.remaining!!), bold = true))
+        }
+
+        // Token Plan usage block.
         metadata?.get("sessionUsed")?.toIntOrNull()?.let {
             rows.add(TooltipRow.BalanceBar("Credits", 100 - it))
         }

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/XiaomiConnectDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/XiaomiConnectDialog.kt
@@ -39,8 +39,11 @@ class XiaomiConnectDialog : DialogWrapper(true) {
         const val XIAOMI_ACCOUNT_URL = "https://account.xiaomi.com/"
         private const val STATUS_WAITING = "<html><i>Waiting for session…</i></html>"
         private const val STATUS_SUCCESS = "<html><font color='green'><b>✓ Session captured!</b></font></html>"
-        private const val STATUS_SUCCESS_NO_REFRESH = "<html><font color='green'><b>✓ Session captured</b></font> " +
-            "<font color='#B87333'>(no passToken — auto-refresh disabled; you'll re-connect when it expires)</font></html>"
+        private const val STATUS_SUCCESS_NO_REFRESH =
+            "<html><font color='green'><b>✓ Session captured</b></font> " +
+                "<font color='#B87333'>" +
+                "(no passToken — auto-refresh disabled; you'll re-connect when it expires)" +
+                "</font></html>"
         private const val STATUS_EMPTY = "<html><font color='red'>Please paste cURL first.</font></html>"
         private const val STATUS_PARSE_ERROR = "<html><font color='red'>Could not parse the pasted text. " +
             "Make sure you used \"Copy as cURL\" on a request to platform.xiaomimimo.com.</font></html>"

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/XiaomiConnectDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/XiaomiConnectDialog.kt
@@ -5,6 +5,7 @@ import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.dsl.builder.AlignX
+import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.panel
 import org.zhavoronkov.tokenpulse.utils.Constants.TEXT_AREA_COLUMNS
 import org.zhavoronkov.tokenpulse.utils.Constants.TEXT_AREA_ROWS
@@ -121,10 +122,45 @@ class XiaomiConnectDialog : DialogWrapper(true) {
 
         separator()
 
+        if (XiaomiJcefLoginDialog.isSupported()) {
+            row {
+                comment(
+                    "Sign in once in an embedded browser window — TokenPulse captures the " +
+                        "session automatically, including the token needed for silent auto-refresh."
+                )
+            }
+            row {
+                cell(
+                    JButton("Sign in to Xiaomi").apply {
+                        addActionListener { openJcefLogin() }
+                    }
+                )
+            }
+            row {
+                cell(statusLabel)
+            }
+
+            collapsibleGroup("Manual capture (advanced)") {
+                manualCaptureRows()
+            }
+        } else {
+            row {
+                comment(
+                    "<html>The embedded browser isn't available in this IDE build, so use " +
+                        "the manual cURL capture below.</html>"
+                )
+            }
+            manualCaptureRows()
+            row {
+                cell(statusLabel)
+            }
+        }
+    }
+
+    private fun Panel.manualCaptureRows() {
         row {
             label("<html><b>Steps:</b></html>")
         }
-
         row {
             comment(
                 "1. Open <a href=\"$XIAOMI_PLATFORM_URL\">Xiaomi Platform</a> and log in<br>" +
@@ -135,7 +171,6 @@ class XiaomiConnectDialog : DialogWrapper(true) {
                     "6. Paste below"
             )
         }
-
         row {
             cell(
                 JButton("Open Xiaomi Platform →").apply {
@@ -143,48 +178,48 @@ class XiaomiConnectDialog : DialogWrapper(true) {
                 }
             )
         }
-
         separator()
-
         row {
             cell(JBLabel("Paste cURL command:"))
         }
-
         row {
             cell(JScrollPane(pasteArea)).align(AlignX.FILL)
         }
-
         separator()
-
         row {
             label("<html><b>Enable auto-refresh (recommended):</b></html>")
         }
-
         row {
             comment(
                 "To let TokenPulse silently re-login when the session expires, also " +
-                    "capture your Xiaomi Passport cookie:<br>" +
-                    "1. In DevTools → Network, filter by <code>account.xiaomi.com</code> " +
-                    "(or <code>serviceLogin</code>)<br>" +
-                    "2. Right-click any request to that host → <b>Copy as cURL</b> and paste below.<br>" +
+                    "capture your Xiaomi Passport cookie. In a new browser tab open " +
+                    "<a href=\"$XIAOMI_ACCOUNT_URL\">account.xiaomi.com</a> (log in if " +
+                    "prompted), then in DevTools → Network right-click the top document " +
+                    "request → <b>Copy as cURL</b> and paste it below.<br>" +
                     "<i>Optional — leave blank to reconnect manually when the session expires.</i>"
             )
         }
-
         row {
             cell(JScrollPane(accountPasteArea)).align(AlignX.FILL)
         }
-
-        row {
-            cell(statusLabel)
-        }
-
         row {
             cell(
                 JButton("Parse").apply {
                     addActionListener { attemptParse() }
                 }
             )
+        }
+    }
+
+    private fun openJcefLogin() {
+        val login = XiaomiJcefLoginDialog()
+        if (login.showAndGet()) {
+            val json = login.capturedSessionJson
+            if (!json.isNullOrBlank()) {
+                capturedSessionJson = json
+                statusLabel.text = STATUS_SUCCESS
+                isOKActionEnabled = true
+            }
         }
     }
 

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/XiaomiConnectDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/XiaomiConnectDialog.kt
@@ -27,13 +27,20 @@ import javax.swing.JTextArea
  * 3. Refresh the page to trigger the request.
  * 4. Right-click the request → "Copy as cURL".
  * 5. Paste the cURL into the text area below.
+ *
+ * Optionally, the user also pastes a cURL from an `account.xiaomi.com` request so
+ * the plugin can capture the long-lived `passToken` and silently re-login when the
+ * short-lived platform session expires (see XiaomiSessionRefresher).
  */
 class XiaomiConnectDialog : DialogWrapper(true) {
 
     companion object {
         const val XIAOMI_PLATFORM_URL = "https://platform.xiaomimimo.com/console/balance"
+        const val XIAOMI_ACCOUNT_URL = "https://account.xiaomi.com/"
         private const val STATUS_WAITING = "<html><i>Waiting for session…</i></html>"
         private const val STATUS_SUCCESS = "<html><font color='green'><b>✓ Session captured!</b></font></html>"
+        private const val STATUS_SUCCESS_NO_REFRESH = "<html><font color='green'><b>✓ Session captured</b></font> " +
+            "<font color='#B87333'>(no passToken — auto-refresh disabled; you'll re-connect when it expires)</font></html>"
         private const val STATUS_EMPTY = "<html><font color='red'>Please paste cURL first.</font></html>"
         private const val STATUS_PARSE_ERROR = "<html><font color='red'>Could not parse the pasted text. " +
             "Make sure you used \"Copy as cURL\" on a request to platform.xiaomimimo.com.</font></html>"
@@ -56,6 +63,23 @@ class XiaomiConnectDialog : DialogWrapper(true) {
                 ph = cookies["api-platform_ph"]
             )
         }
+
+        /**
+         * Extract the long-lived Xiaomi Passport cookies from a cURL command copied
+         * from an `account.xiaomi.com` request. Returns null if no cookie header /
+         * no `passToken` is present.
+         */
+        fun extractPassportFromCurl(text: String): XiaomiPassportCookies? {
+            val cookieString = CurlCookieExtractor.extractCookieString(text) ?: return null
+            val cookies = CurlCookieExtractor.parseCookieString(cookieString)
+            val passToken = cookies["passToken"]
+            if (passToken.isNullOrBlank()) return null
+            return XiaomiPassportCookies(
+                passToken = passToken,
+                userId = cookies["userId"],
+                cUserId = cookies["cUserId"]
+            )
+        }
     }
 
     var capturedSessionJson: String? = null
@@ -64,6 +88,11 @@ class XiaomiConnectDialog : DialogWrapper(true) {
     private val statusLabel = JBLabel(STATUS_WAITING)
 
     private val pasteArea = JTextArea(TEXT_AREA_ROWS, TEXT_AREA_COLUMNS).apply {
+        lineWrap = true
+        wrapStyleWord = true
+    }
+
+    private val accountPasteArea = JTextArea(TEXT_AREA_ROWS, TEXT_AREA_COLUMNS).apply {
         lineWrap = true
         wrapStyleWord = true
     }
@@ -122,6 +151,27 @@ class XiaomiConnectDialog : DialogWrapper(true) {
             cell(JScrollPane(pasteArea)).align(AlignX.FILL)
         }
 
+        separator()
+
+        row {
+            label("<html><b>Enable auto-refresh (recommended):</b></html>")
+        }
+
+        row {
+            comment(
+                "To let TokenPulse silently re-login when the session expires, also " +
+                    "capture your Xiaomi Passport cookie:<br>" +
+                    "1. In DevTools → Network, filter by <code>account.xiaomi.com</code> " +
+                    "(or <code>serviceLogin</code>)<br>" +
+                    "2. Right-click any request to that host → <b>Copy as cURL</b> and paste below.<br>" +
+                    "<i>Optional — leave blank to reconnect manually when the session expires.</i>"
+            )
+        }
+
+        row {
+            cell(JScrollPane(accountPasteArea)).align(AlignX.FILL)
+        }
+
         row {
             cell(statusLabel)
         }
@@ -158,8 +208,25 @@ class XiaomiConnectDialog : DialogWrapper(true) {
                 return
             }
 
-            capturedSessionJson = gson.toJson(cookies)
-            statusLabel.text = STATUS_SUCCESS
+            val passport = accountPasteArea.text.trim()
+                .takeIf { it.isNotEmpty() }
+                ?.let { extractPassportFromCurl(it) }
+
+            val session = XiaomiSessionCookies(
+                serviceToken = cookies.serviceToken,
+                userId = cookies.userId,
+                slh = cookies.slh,
+                ph = cookies.ph,
+                passToken = passport?.passToken,
+                cUserId = passport?.cUserId
+            )
+
+            capturedSessionJson = gson.toJson(session)
+            statusLabel.text = if (passport?.passToken.isNullOrBlank()) {
+                STATUS_SUCCESS_NO_REFRESH
+            } else {
+                STATUS_SUCCESS
+            }
             isOKActionEnabled = true
         } catch (e: Exception) {
             statusLabel.text = STATUS_PARSE_ERROR
@@ -170,6 +237,14 @@ class XiaomiConnectDialog : DialogWrapper(true) {
         val serviceToken: String? = null,
         val userId: String? = null,
         val slh: String? = null,
-        val ph: String? = null
+        val ph: String? = null,
+        val passToken: String? = null,
+        val cUserId: String? = null
+    )
+
+    data class XiaomiPassportCookies(
+        val passToken: String? = null,
+        val userId: String? = null,
+        val cUserId: String? = null
     )
 }

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/XiaomiCookieHarvest.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/XiaomiCookieHarvest.kt
@@ -1,0 +1,59 @@
+package org.zhavoronkov.tokenpulse.ui
+
+import com.google.gson.Gson
+
+/**
+ * Pure cookie-name/value -> Xiaomi session JSON mapping.
+ *
+ * Kept separate from [XiaomiJcefLoginDialog] so it can be unit-tested without
+ * launching JCEF (which cannot run headless in unit tests). The output JSON
+ * shape is identical to what [XiaomiConnectDialog.attemptParse] produces, so
+ * downstream consumers (persistence, provider client) don't care whether the
+ * source was a pasted cURL or an in-IDE JCEF login.
+ *
+ * platformCookies expected keys: api-platform_serviceToken, userId,
+ * api-platform_slh, api-platform_ph.
+ * passportCookies expected keys: passToken, userId, cUserId.
+ *
+ * passportCookies is optional. Without it, auto-refresh is disabled but the
+ * session is still usable until it expires.
+ */
+object XiaomiCookieHarvest {
+
+    private val gson = Gson()
+
+    /**
+     * Build the session JSON if the required platform cookies are present.
+     * Returns null if serviceToken or userId is missing (session unusable).
+     */
+    fun buildSessionJson(
+        platformCookies: Map<String, String>,
+        passportCookies: Map<String, String> = emptyMap()
+    ): String? {
+        val cookies = buildSessionCookies(platformCookies, passportCookies) ?: return null
+        return gson.toJson(cookies)
+    }
+
+    fun buildSessionCookies(
+        platformCookies: Map<String, String>,
+        passportCookies: Map<String, String> = emptyMap()
+    ): XiaomiConnectDialog.XiaomiSessionCookies? {
+        val serviceToken = platformCookies["api-platform_serviceToken"]?.takeIf { it.isNotBlank() }
+        val userId = platformCookies["userId"]?.takeIf { it.isNotBlank() }
+            ?: passportCookies["userId"]?.takeIf { it.isNotBlank() }
+        if (serviceToken.isNullOrBlank() || userId.isNullOrBlank()) return null
+
+        return XiaomiConnectDialog.XiaomiSessionCookies(
+            serviceToken = serviceToken,
+            userId = userId,
+            slh = platformCookies["api-platform_slh"]?.takeIf { it.isNotBlank() },
+            ph = platformCookies["api-platform_ph"]?.takeIf { it.isNotBlank() },
+            passToken = passportCookies["passToken"]?.takeIf { it.isNotBlank() },
+            cUserId = passportCookies["cUserId"]?.takeIf { it.isNotBlank() }
+        )
+    }
+
+    /** True if we captured enough to enable silent re-login on expiry. */
+    fun hasRefreshableSession(cookies: XiaomiConnectDialog.XiaomiSessionCookies?): Boolean =
+        cookies?.passToken?.isNotBlank() == true && cookies.userId?.isNotBlank() == true
+}

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/XiaomiJcefLoginDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/XiaomiJcefLoginDialog.kt
@@ -1,0 +1,201 @@
+package org.zhavoronkov.tokenpulse.ui
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.util.Disposer
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.jcef.JBCefApp
+import com.intellij.ui.jcef.JBCefBrowser
+import com.intellij.ui.jcef.JBCefCookie
+import org.cef.browser.CefBrowser
+import org.cef.browser.CefFrame
+import org.cef.handler.CefLoadHandlerAdapter
+import org.zhavoronkov.tokenpulse.utils.TokenPulseLogger
+import java.awt.BorderLayout
+import java.awt.Dimension
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.swing.BoxLayout
+import javax.swing.JButton
+import javax.swing.JComponent
+import javax.swing.JPanel
+import javax.swing.SwingUtilities
+
+/**
+ * One-click Xiaomi sign-in via an embedded Chromium (JCEF) browser.
+ *
+ * The user logs in normally inside a real Chromium window inside the IDE.
+ * Captcha / 2FA / passkeys all work as in a regular browser. When the browser
+ * lands back on `platform.xiaomimimo.com/console/...`, we harvest cookies from
+ * both `platform.xiaomimimo.com` (short-lived session) AND `account.xiaomi.com`
+ * (long-lived `passToken` for silent re-login).
+ *
+ * JCEF's cookie manager can read HttpOnly cookies (unlike page JS or a hosted
+ * "proxy page"), which is the key enabler: `passToken` is HttpOnly on
+ * `Domain=.xiaomi.com`, so this is the only zero-install way to capture it.
+ *
+ * On IDE builds where [JBCefApp.isSupported] is false, this dialog cannot be
+ * used — callers must gate on that flag and fall back to the cURL paste flow
+ * ([XiaomiConnectDialog]).
+ */
+class XiaomiJcefLoginDialog : DialogWrapper(true) {
+
+    /** Session JSON, populated on successful login. Null if the user cancelled. */
+    var capturedSessionJson: String? = null
+        private set
+
+    private val browser: JBCefBrowser = JBCefBrowser.createBuilder()
+        .setUrl(START_URL)
+        .setEnableOpenDevToolsMenuItem(false)
+        .build()
+
+    private val statusLabel = JBLabel(STATUS_WAITING)
+    private val captureButton = JButton("Capture session").apply {
+        addActionListener { triggerHarvest("manual button") }
+    }
+
+    private val harvestInProgress = AtomicBoolean(false)
+    private val captured = AtomicBoolean(false)
+
+    init {
+        title = "Sign in to Xiaomi"
+        setOKButtonText("Done")
+        isOKActionEnabled = false
+        // Dispose the JCEF browser + client whenever this dialog is closed.
+        Disposer.register(disposable, browser)
+        installLoadHandler()
+        init()
+    }
+
+    override fun createCenterPanel(): JComponent {
+        val root = JPanel(BorderLayout())
+
+        val header = JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+            add(JBLabel("<html><b>Log in to your Xiaomi account below.</b></html>"))
+            add(
+                JBLabel(
+                    "<html>The session is captured automatically once the console loads. " +
+                        "If it doesn't, click <b>Capture session</b>.</html>"
+                )
+            )
+        }
+        root.add(header, BorderLayout.NORTH)
+
+        val browserComponent = browser.component.apply {
+            preferredSize = Dimension(BROWSER_WIDTH, BROWSER_HEIGHT)
+        }
+        root.add(browserComponent, BorderLayout.CENTER)
+
+        val footer = JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+            add(statusLabel)
+            add(captureButton)
+        }
+        root.add(footer, BorderLayout.SOUTH)
+
+        return root
+    }
+
+    private fun installLoadHandler() {
+        // Auto-detect: whenever the top frame finishes loading a platform console URL,
+        // harvest cookies. Runs on the CEF UI thread — dispatch work to a pool thread.
+        val handler = object : CefLoadHandlerAdapter() {
+            override fun onLoadEnd(browser: CefBrowser?, frame: CefFrame?, httpStatusCode: Int) {
+                if (frame?.isMain != true) return
+                val url = browser?.url.orEmpty()
+                if (looksLikeConsoleUrl(url)) {
+                    triggerHarvest("auto-detect: $url")
+                }
+            }
+        }
+        browser.jbCefClient.addLoadHandler(handler, browser.cefBrowser)
+    }
+
+    private fun looksLikeConsoleUrl(url: String): Boolean {
+        if (!url.startsWith("https://platform.xiaomimimo.com")) return false
+        // Platform uses a hash router (#/console/balance), but we accept any path
+        // under the host once the top-level document is at platform.xiaomimimo.com.
+        return url.contains("/console") || url.contains("#/console") ||
+            url.trimEnd('/').endsWith("platform.xiaomimimo.com")
+    }
+
+    private fun triggerHarvest(reason: String) {
+        if (captured.get() || !harvestInProgress.compareAndSet(false, true)) return
+        TokenPulseLogger.Provider.debug("Xiaomi JCEF: harvesting cookies ($reason)")
+        ApplicationManager.getApplication().executeOnPooledThread {
+            try {
+                val platform = readCookies(PLATFORM_URL)
+                val passport = readCookies(ACCOUNT_URL)
+                val sessionJson = XiaomiCookieHarvest.buildSessionJson(platform, passport)
+                SwingUtilities.invokeLater { onHarvestFinished(sessionJson, platform, passport) }
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                TokenPulseLogger.Provider.debug("Xiaomi JCEF: harvest failed: ${e.message}")
+                SwingUtilities.invokeLater { onHarvestFinished(null, emptyMap(), emptyMap()) }
+            } finally {
+                harvestInProgress.set(false)
+            }
+        }
+    }
+
+    /**
+     * Read cookies for [url] from the browser's cookie manager, INCLUDING
+     * HttpOnly cookies. The future-returning overload is used explicitly
+     * because the synchronous overloads warn about freezes when called from
+     * a browser callback.
+     */
+    private fun readCookies(url: String): Map<String, String> {
+        val future = browser.jbCefCookieManager.getCookies(url, true) ?: return emptyMap()
+        val cookies: List<JBCefCookie> = try {
+            future.get(COOKIE_TIMEOUT_MS, TimeUnit.MILLISECONDS).orEmpty()
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            TokenPulseLogger.Provider.debug("Xiaomi JCEF: getCookies($url) failed: ${e.message}")
+            return emptyMap()
+        }
+        return cookies.associate { it.name to it.value }
+    }
+
+    private fun onHarvestFinished(
+        sessionJson: String?,
+        platform: Map<String, String>,
+        passport: Map<String, String>
+    ) {
+        if (sessionJson == null) {
+            statusLabel.text = STATUS_INCOMPLETE
+            TokenPulseLogger.Provider.debug(
+                "Xiaomi JCEF: incomplete cookies platform=${platform.keys} passport=${passport.keys}"
+            )
+            return
+        }
+        capturedSessionJson = sessionJson
+        captured.set(true)
+        statusLabel.text = if (passport["passToken"].isNullOrBlank()) STATUS_SUCCESS_NO_REFRESH else STATUS_SUCCESS
+        isOKActionEnabled = true
+    }
+
+    companion object {
+        // Landing on the console URL redirects through Xiaomi Passport when not authed,
+        // and back to /console/balance once the user completes login.
+        const val START_URL = "https://platform.xiaomimimo.com/#/console/balance"
+        private const val PLATFORM_URL = "https://platform.xiaomimimo.com/"
+        private const val ACCOUNT_URL = "https://account.xiaomi.com/"
+
+        private const val BROWSER_WIDTH = 900
+        private const val BROWSER_HEIGHT = 640
+        private const val COOKIE_TIMEOUT_MS = 5_000L
+
+        private const val STATUS_WAITING = "<html><i>Waiting for you to sign in…</i></html>"
+        private const val STATUS_SUCCESS = "<html><font color='green'><b>✓ Session captured!</b></font></html>"
+        private const val STATUS_SUCCESS_NO_REFRESH =
+            "<html><font color='green'><b>✓ Session captured</b></font> " +
+                "<font color='#B87333'>" +
+                "(no passToken — auto-refresh disabled; you'll re-connect when it expires)" +
+                "</font></html>"
+        private const val STATUS_INCOMPLETE =
+            "<html><font color='red'>Not signed in yet.</font> " +
+                "Finish the Xiaomi login above, then click <b>Capture session</b>.</html>"
+
+        /** True if JCEF is usable on this IDE build (JBR + platform support). */
+        fun isSupported(): Boolean = JBCefApp.isSupported()
+    }
+}

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/ClaudeCredentialReaderTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/ClaudeCredentialReaderTest.kt
@@ -1,5 +1,6 @@
 package org.zhavoronkov.tokenpulse.provider
 
+import com.google.gson.JsonParser
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
@@ -11,10 +12,9 @@ import org.zhavoronkov.tokenpulse.provider.anthropic.claudecode.ClaudeCredential
 import org.zhavoronkov.tokenpulse.provider.anthropic.claudecode.isClaudeTokenExpired
 import org.zhavoronkov.tokenpulse.utils.HostOs
 import java.io.File
-import java.nio.file.Path
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.attribute.PosixFilePermission
-import com.google.gson.JsonParser
 
 /**
  * Tests for [ClaudeCredentialReader]'s file-mode path. Constructed with

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiProviderClientTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiProviderClientTest.kt
@@ -63,61 +63,104 @@ class XiaomiProviderClientTest {
         server.shutdown()
     }
 
+    /**
+     * The unified client always queries BOTH `/api/v1/balance` and
+     * `/api/v1/tokenPlan/usage`. Install a path-based dispatcher so each test
+     * controls each endpoint independently. An endpoint whose body is null
+     * responds 404 (a non-auth failure the composer silently drops).
+     */
+    private fun serveBoth(balanceBody: String?, tokenBody: String?) {
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                val path = request.path ?: ""
+                return when {
+                    path.startsWith("/api/v1/tokenPlan") ->
+                        tokenBody?.let { MockResponse().setResponseCode(200).setBody(it) }
+                            ?: MockResponse().setResponseCode(404)
+                    path.startsWith("/api/v1/balance") ->
+                        balanceBody?.let { MockResponse().setResponseCode(200).setBody(it) }
+                            ?: MockResponse().setResponseCode(404)
+                    else -> MockResponse().setResponseCode(404)
+                }
+            }
+        }
+    }
+
+    /** Serve the same status code for BOTH endpoints (used for error-path tests). */
+    private fun serveBothStatus(code: Int, body: String = "") {
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse =
+                MockResponse().setResponseCode(code).setBody(body)
+        }
+    }
+
     @Test
-    fun `fetchBalance returns dollar balance for XIAOMI_API`() {
-        server.enqueue(
-            MockResponse()
-                .setResponseCode(200)
-                .setBody(
-                    """{"code":0,"message":"","data":{"balance":"55.48","frozenBalance":"0.00","currency":"USD","overdraftLimit":"0.00","remainingOverdraftLimit":"0.00","giftBalance":"55.48","cashBalance":"0.00"}}"""
-                )
+    fun `fetchBalance returns unified dollar balance`() {
+        serveBoth(
+            balanceBody =
+            """{"code":0,"message":"","data":{"balance":"55.48","frozenBalance":"0.00","currency":"USD","overdraftLimit":"0.00","remainingOverdraftLimit":"0.00","giftBalance":"55.48","cashBalance":"0.00"}}""",
+            tokenBody = null
         )
 
-        val result = client.fetchBalance(account(ConnectionType.XIAOMI_API), validSession)
+        val result = client.fetchBalance(account(ConnectionType.XIAOMI), validSession)
 
         assertTrue(result is ProviderResult.Success)
         val success = result as ProviderResult.Success
-        assertEquals(ConnectionType.XIAOMI_API, success.snapshot.connectionType)
+        assertEquals(ConnectionType.XIAOMI, success.snapshot.connectionType)
         assertEquals("55.48", success.snapshot.balance.credits?.remaining?.toPlainString())
         assertEquals("USD", success.snapshot.metadata["currency"])
         assertEquals("55.48", success.snapshot.metadata["giftBalance"])
     }
 
     @Test
-    fun `fetchBalance returns Credits usage for XIAOMI_TOKEN_PLAN`() {
-        server.enqueue(
-            MockResponse()
-                .setResponseCode(200)
-                .setBody(
-                    """{"code":0,"message":"","data":{"monthUsage":{"percent":0.248,"items":[{"name":"month_total_token","used":2727524596,"limit":11000000000,"percent":0.248}]},"usage":{"percent":0.25,"items":[{"name":"plan_total_token","used":2727524596,"limit":11000000000,"percent":0.25}]}}}"""
-                )
+    fun `fetchBalance returns unified Token Plan credits`() {
+        serveBoth(
+            balanceBody = null,
+            tokenBody =
+            """{"code":0,"message":"","data":{"monthUsage":{"percent":0.248,"items":[{"name":"month_total_token","used":2727524596,"limit":11000000000,"percent":0.248}]},"usage":{"percent":0.25,"items":[{"name":"plan_total_token","used":2727524596,"limit":11000000000,"percent":0.25}]}}}"""
         )
 
-        val result = client.fetchBalance(account(ConnectionType.XIAOMI_TOKEN_PLAN), validSession)
+        val result = client.fetchBalance(account(ConnectionType.XIAOMI), validSession)
 
         assertTrue(result is ProviderResult.Success)
         val success = result as ProviderResult.Success
-        assertEquals(ConnectionType.XIAOMI_TOKEN_PLAN, success.snapshot.connectionType)
+        assertEquals(ConnectionType.XIAOMI, success.snapshot.connectionType)
         assertEquals(2727524596L, success.snapshot.balance.tokens?.used)
         assertEquals(11000000000L, success.snapshot.balance.tokens?.total)
         assertEquals(8272475404L, success.snapshot.balance.tokens?.remaining)
     }
 
     @Test
-    fun `fetchBalance returns AuthError when session is expired`() {
-        server.enqueue(
-            MockResponse()
-                .setResponseCode(401)
+    fun `fetchBalance merges dollar balance and Token Plan credits into one snapshot`() {
+        serveBoth(
+            balanceBody = """{"code":0,"message":"","data":{"balance":"55.48","currency":"USD","giftBalance":"55.48"}}""",
+            tokenBody =
+            """{"code":0,"message":"","data":{"monthUsage":{"percent":0.248,"items":[{"used":2727524596,"limit":11000000000}]}}}"""
         )
 
-        val result = client.fetchBalance(account(ConnectionType.XIAOMI_API), validSession)
+        val result = client.fetchBalance(account(ConnectionType.XIAOMI), validSession)
+
+        assertTrue(result is ProviderResult.Success)
+        val success = result as ProviderResult.Success
+        assertEquals(ConnectionType.XIAOMI, success.snapshot.connectionType)
+        assertEquals("55.48", success.snapshot.balance.credits?.remaining?.toPlainString())
+        assertEquals(2727524596L, success.snapshot.balance.tokens?.used)
+        assertEquals("USD", success.snapshot.metadata["currency"])
+        assertEquals("24", success.snapshot.metadata["sessionUsed"])
+    }
+
+    @Test
+    fun `fetchBalance returns AuthError when session is expired`() {
+        serveBothStatus(401)
+
+        val result = client.fetchBalance(account(ConnectionType.XIAOMI), validSession)
 
         assertTrue(result is ProviderResult.Failure.AuthError)
     }
 
     @Test
     fun `fetchBalance returns AuthError when session JSON is invalid`() {
-        val result = client.fetchBalance(account(ConnectionType.XIAOMI_API), "not-valid-json")
+        val result = client.fetchBalance(account(ConnectionType.XIAOMI), "not-valid-json")
 
         assertTrue(result is ProviderResult.Failure.AuthError)
     }
@@ -128,45 +171,40 @@ class XiaomiProviderClientTest {
             XiaomiProviderClient.XiaomiSession(serviceToken = null, userId = "12345")
         )
 
-        val result = client.fetchBalance(account(ConnectionType.XIAOMI_API), badSession)
+        val result = client.fetchBalance(account(ConnectionType.XIAOMI), badSession)
 
         assertTrue(result is ProviderResult.Failure.AuthError)
     }
 
     @Test
     fun `testCredentials returns success for valid session`() {
-        server.enqueue(
-            MockResponse()
-                .setResponseCode(200)
-                .setBody("""{"code":0,"message":"","data":{"balance":"10.00","currency":"USD"}}""")
+        serveBoth(
+            balanceBody = """{"code":0,"message":"","data":{"balance":"10.00","currency":"USD"}}""",
+            tokenBody = null
         )
 
-        val result = client.testCredentials(account(ConnectionType.XIAOMI_API), validSession)
+        val result = client.testCredentials(account(ConnectionType.XIAOMI), validSession)
 
         assertTrue(result is ProviderResult.Success)
     }
 
     @Test
     fun `testCredentials returns AuthError for expired session`() {
-        server.enqueue(
-            MockResponse()
-                .setResponseCode(401)
-        )
+        serveBothStatus(401)
 
-        val result = client.testCredentials(account(ConnectionType.XIAOMI_API), validSession)
+        val result = client.testCredentials(account(ConnectionType.XIAOMI), validSession)
 
         assertTrue(result is ProviderResult.Failure.AuthError)
     }
 
     @Test
     fun `fetchBalance sends correct cookies in request`() {
-        server.enqueue(
-            MockResponse()
-                .setResponseCode(200)
-                .setBody("""{"code":0,"message":"","data":{"balance":"0","currency":"USD"}}""")
+        serveBoth(
+            balanceBody = """{"code":0,"message":"","data":{"balance":"0","currency":"USD"}}""",
+            tokenBody = null
         )
 
-        client.fetchBalance(account(ConnectionType.XIAOMI_API), validSession)
+        client.fetchBalance(account(ConnectionType.XIAOMI), validSession)
 
         val request = server.takeRequest()
         val cookie = request.getHeader("Cookie") ?: ""
@@ -178,42 +216,30 @@ class XiaomiProviderClientTest {
 
     @Test
     fun `fetchBalance returns RateLimited on 429`() {
-        server.enqueue(
-            MockResponse()
-                .setResponseCode(429)
-        )
+        serveBothStatus(429)
 
-        val result = client.fetchBalance(account(ConnectionType.XIAOMI_API), validSession)
+        val result = client.fetchBalance(account(ConnectionType.XIAOMI), validSession)
 
         assertTrue(result is ProviderResult.Failure.RateLimited)
     }
 
     @Test
     fun `fetchBalance returns NetworkError on 500`() {
-        server.enqueue(
-            MockResponse()
-                .setResponseCode(500)
-        )
+        serveBothStatus(500)
 
-        val result = client.fetchBalance(account(ConnectionType.XIAOMI_API), validSession)
+        val result = client.fetchBalance(account(ConnectionType.XIAOMI), validSession)
 
         assertTrue(result is ProviderResult.Failure.NetworkError)
     }
 
     @Test
-    fun `testCredentials returns success for XIAOMI_TOKEN_PLAN`() {
-        server.enqueue(
-            MockResponse()
-                .setResponseCode(200)
-                .setBody(
-                    """{"code":0,"message":"","data":{"monthUsage":{"percent":0.25,"items":[]}}}"""
-                )
+    fun `testCredentials returns success with only Token Plan data`() {
+        serveBoth(
+            balanceBody = null,
+            tokenBody = """{"code":0,"message":"","data":{"monthUsage":{"percent":0.25,"items":[]}}}"""
         )
 
-        val result = client.testCredentials(
-            account(ConnectionType.XIAOMI_TOKEN_PLAN),
-            validSession
-        )
+        val result = client.testCredentials(account(ConnectionType.XIAOMI), validSession)
 
         assertTrue(result is ProviderResult.Success)
     }
@@ -233,18 +259,12 @@ class XiaomiProviderClientTest {
 
     @Test
     fun `fetchTokenPlanUsage handles null monthUsage gracefully`() {
-        server.enqueue(
-            MockResponse()
-                .setResponseCode(200)
-                .setBody(
-                    """{"code":0,"message":"","data":{"monthUsage":null}}"""
-                )
+        serveBoth(
+            balanceBody = null,
+            tokenBody = """{"code":0,"message":"","data":{"monthUsage":null}}"""
         )
 
-        val result = client.fetchBalance(
-            account(ConnectionType.XIAOMI_TOKEN_PLAN),
-            validSession
-        )
+        val result = client.fetchBalance(account(ConnectionType.XIAOMI), validSession)
 
         assertTrue(result is ProviderResult.Success)
         val success = result as ProviderResult.Success
@@ -257,18 +277,12 @@ class XiaomiProviderClientTest {
 
     @Test
     fun `fetchTokenPlanUsage handles null items array gracefully`() {
-        server.enqueue(
-            MockResponse()
-                .setResponseCode(200)
-                .setBody(
-                    """{"code":0,"message":"","data":{"monthUsage":{"percent":0.0,"items":null}}}"""
-                )
+        serveBoth(
+            balanceBody = null,
+            tokenBody = """{"code":0,"message":"","data":{"monthUsage":{"percent":0.0,"items":null}}}"""
         )
 
-        val result = client.fetchBalance(
-            account(ConnectionType.XIAOMI_TOKEN_PLAN),
-            validSession
-        )
+        val result = client.fetchBalance(account(ConnectionType.XIAOMI), validSession)
 
         assertTrue(result is ProviderResult.Success)
         val success = result as ProviderResult.Success
@@ -280,18 +294,12 @@ class XiaomiProviderClientTest {
 
     @Test
     fun `fetchTokenPlanUsage handles null data gracefully`() {
-        server.enqueue(
-            MockResponse()
-                .setResponseCode(200)
-                .setBody(
-                    """{"code":0,"message":"","data":null}"""
-                )
+        serveBoth(
+            balanceBody = null,
+            tokenBody = """{"code":0,"message":"","data":null}"""
         )
 
-        val result = client.fetchBalance(
-            account(ConnectionType.XIAOMI_TOKEN_PLAN),
-            validSession
-        )
+        val result = client.fetchBalance(account(ConnectionType.XIAOMI), validSession)
 
         assertTrue(result is ProviderResult.Success)
         val success = result as ProviderResult.Success
@@ -303,13 +311,9 @@ class XiaomiProviderClientTest {
 
     @Test
     fun `fetchApiBalance returns AuthError when code is not zero`() {
-        server.enqueue(
-            MockResponse()
-                .setResponseCode(200)
-                .setBody("""{"code":-1,"message":"Token expired","data":{}}""")
-        )
+        serveBothStatus(200, """{"code":-1,"message":"Token expired","data":{}}""")
 
-        val result = client.fetchBalance(account(ConnectionType.XIAOMI_API), validSession)
+        val result = client.fetchBalance(account(ConnectionType.XIAOMI), validSession)
 
         assertTrue(result is ProviderResult.Failure.AuthError)
         assertEquals(
@@ -320,16 +324,9 @@ class XiaomiProviderClientTest {
 
     @Test
     fun `fetchTokenPlanUsage returns AuthError when code is not zero`() {
-        server.enqueue(
-            MockResponse()
-                .setResponseCode(200)
-                .setBody("""{"code":-1,"message":"Session invalid","data":{}}""")
-        )
+        serveBothStatus(200, """{"code":-1,"message":"Session invalid","data":{}}""")
 
-        val result = client.fetchBalance(
-            account(ConnectionType.XIAOMI_TOKEN_PLAN),
-            validSession
-        )
+        val result = client.fetchBalance(account(ConnectionType.XIAOMI), validSession)
 
         assertTrue(result is ProviderResult.Failure.AuthError)
         assertEquals(
@@ -340,18 +337,12 @@ class XiaomiProviderClientTest {
 
     @Test
     fun `fetchTokenPlanUsage handles missing monthUsage items`() {
-        server.enqueue(
-            MockResponse()
-                .setResponseCode(200)
-                .setBody(
-                    """{"code":0,"message":"","data":{"monthUsage":{"percent":0.0}}}"""
-                )
+        serveBoth(
+            balanceBody = null,
+            tokenBody = """{"code":0,"message":"","data":{"monthUsage":{"percent":0.0}}}"""
         )
 
-        val result = client.fetchBalance(
-            account(ConnectionType.XIAOMI_TOKEN_PLAN),
-            validSession
-        )
+        val result = client.fetchBalance(account(ConnectionType.XIAOMI), validSession)
 
         assertTrue(result is ProviderResult.Success)
         val success = result as ProviderResult.Success
@@ -362,13 +353,12 @@ class XiaomiProviderClientTest {
 
     @Test
     fun `fetchApiBalance handles missing balance fields with zero fallback`() {
-        server.enqueue(
-            MockResponse()
-                .setResponseCode(200)
-                .setBody("""{"code":0,"message":"","data":{"currency":"USD"}}""")
+        serveBoth(
+            balanceBody = """{"code":0,"message":"","data":{"currency":"USD"}}""",
+            tokenBody = null
         )
 
-        val result = client.fetchBalance(account(ConnectionType.XIAOMI_API), validSession)
+        val result = client.fetchBalance(account(ConnectionType.XIAOMI), validSession)
 
         assertTrue(result is ProviderResult.Success)
         val success = result as ProviderResult.Success
@@ -438,7 +428,7 @@ class XiaomiProviderClientTest {
         }
 
         val c = clientWithRefresh { _, json -> savedJson[0] = json }
-        val result = c.fetchBalance(account(ConnectionType.XIAOMI_API), sessionWithPassport)
+        val result = c.fetchBalance(account(ConnectionType.XIAOMI), sessionWithPassport)
 
         assertTrue(result is ProviderResult.Success)
         assertEquals(2, balanceHits)
@@ -449,26 +439,24 @@ class XiaomiProviderClientTest {
 
     @Test
     fun `fetchBalance does not refresh when no passToken`() {
-        server.enqueue(MockResponse().setResponseCode(401))
+        // Both endpoints return 401; the session lacks a passToken so no silent
+        // re-login is attempted and the session writer is never invoked.
+        serveBothStatus(401)
 
         var writerCalled = false
         val c = clientWithRefresh { _, _ -> writerCalled = true }
-        val result = c.fetchBalance(account(ConnectionType.XIAOMI_API), validSession)
+        val result = c.fetchBalance(account(ConnectionType.XIAOMI), validSession)
 
         assertTrue(result is ProviderResult.Failure.AuthError)
         assertEquals(false, writerCalled)
-        assertEquals(1, server.requestCount)
     }
 
     @Test
     fun `fetchBalance treats HTML body as AuthError not ParseError`() {
-        server.enqueue(
-            MockResponse().setResponseCode(200)
-                .setBody("<!doctype html><html><body>Login</body></html>")
-        )
+        serveBothStatus(200, "<!doctype html><html><body>Login</body></html>")
 
         // No passport => cannot refresh => surfaces the AuthError.
-        val result = client.fetchBalance(account(ConnectionType.XIAOMI_API), validSession)
+        val result = client.fetchBalance(account(ConnectionType.XIAOMI), validSession)
 
         assertTrue(result is ProviderResult.Failure.AuthError)
     }
@@ -488,7 +476,7 @@ class XiaomiProviderClientTest {
         }
 
         val c = clientWithRefresh { _, _ -> }
-        val result = c.fetchBalance(account(ConnectionType.XIAOMI_API), sessionWithPassport)
+        val result = c.fetchBalance(account(ConnectionType.XIAOMI), sessionWithPassport)
 
         assertTrue(result is ProviderResult.Failure.AuthError)
         // First attempt + exactly one retry after refresh.

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiProviderClientTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiProviderClientTest.kt
@@ -2,8 +2,10 @@ package org.zhavoronkov.tokenpulse.provider.xiaomi
 
 import com.google.gson.Gson
 import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -31,6 +33,17 @@ class XiaomiProviderClientTest {
             userId = "12345",
             slh = "test-slh",
             ph = "test-ph"
+        )
+    )
+
+    private val sessionWithPassport = gson.toJson(
+        XiaomiProviderClient.XiaomiSession(
+            serviceToken = "old-token",
+            userId = "12345",
+            slh = "old-slh",
+            ph = "old-ph",
+            passToken = "pass-abc",
+            cUserId = "cuser-9"
         )
     )
 
@@ -373,5 +386,112 @@ class XiaomiProviderClientTest {
         val result = client.testCredentials(unsupportedAccount, validSession)
 
         assertTrue(result is ProviderResult.Failure.AuthError)
+    }
+
+    // ---- Silent refresh (headless re-login) ----
+
+    /** A client whose refresher + balance calls both hit this mock server. */
+    private fun clientWithRefresh(writer: (String, String) -> Unit): XiaomiProviderClient {
+        val base = server.url("/").toString().removeSuffix("/")
+        return XiaomiProviderClient(
+            httpClient = OkHttpClient(),
+            gson = gson,
+            baseUrl = base,
+            refresher = XiaomiSessionRefresher(OkHttpClient(), gson, base, base),
+            sessionWriter = writer
+        )
+    }
+
+    private val refreshChainOk: (RecordedRequest) -> MockResponse? = { req ->
+        when {
+            (req.path ?: "").startsWith("/api/v1/genLoginUrl") -> MockResponse().setResponseCode(302)
+                .setHeader("Location", "https://account.xiaomi.com/pass/serviceLogin?sid=api-platform")
+            (req.path ?: "").startsWith("/pass/serviceLogin") -> MockResponse().setResponseCode(200)
+                .setBody(
+                    "&&&START&&&{\"ssecurity\":\"s\",\"location\":\"https://platform.xiaomimimo.com/sts?sign=z\"}"
+                )
+            (req.path ?: "").startsWith("/sts") -> MockResponse().setResponseCode(302)
+                .addHeader("Set-Cookie", "api-platform_serviceToken=NEW-TOKEN; Path=/")
+                .addHeader("Set-Cookie", "api-platform_slh=NEW-SLH; Path=/")
+            else -> null
+        }
+    }
+
+    @Test
+    fun `fetchBalance refreshes on 401 then retries successfully`() {
+        var balanceHits = 0
+        val savedJson = arrayOfNulls<String>(1)
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                refreshChainOk(request)?.let { return it }
+                if ((request.path ?: "").startsWith("/api/v1/balance")) {
+                    balanceHits++
+                    return if (balanceHits == 1) {
+                        MockResponse().setResponseCode(401)
+                    } else {
+                        MockResponse().setResponseCode(200)
+                            .setBody("""{"code":0,"message":"","data":{"balance":"7.00","currency":"USD"}}""")
+                    }
+                }
+                return MockResponse().setResponseCode(404)
+            }
+        }
+
+        val c = clientWithRefresh { _, json -> savedJson[0] = json }
+        val result = c.fetchBalance(account(ConnectionType.XIAOMI_API), sessionWithPassport)
+
+        assertTrue(result is ProviderResult.Success)
+        assertEquals(2, balanceHits)
+        // Persisted the refreshed session with the new token.
+        val saved = savedJson[0]
+        assertTrue(saved != null && saved.contains("NEW-TOKEN"))
+    }
+
+    @Test
+    fun `fetchBalance does not refresh when no passToken`() {
+        server.enqueue(MockResponse().setResponseCode(401))
+
+        var writerCalled = false
+        val c = clientWithRefresh { _, _ -> writerCalled = true }
+        val result = c.fetchBalance(account(ConnectionType.XIAOMI_API), validSession)
+
+        assertTrue(result is ProviderResult.Failure.AuthError)
+        assertEquals(false, writerCalled)
+        assertEquals(1, server.requestCount)
+    }
+
+    @Test
+    fun `fetchBalance treats HTML body as AuthError not ParseError`() {
+        server.enqueue(
+            MockResponse().setResponseCode(200)
+                .setBody("<!doctype html><html><body>Login</body></html>")
+        )
+
+        // No passport => cannot refresh => surfaces the AuthError.
+        val result = client.fetchBalance(account(ConnectionType.XIAOMI_API), validSession)
+
+        assertTrue(result is ProviderResult.Failure.AuthError)
+    }
+
+    @Test
+    fun `fetchBalance retries only once when refresh does not fix expiry`() {
+        var balanceHits = 0
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                refreshChainOk(request)?.let { return it }
+                if ((request.path ?: "").startsWith("/api/v1/balance")) {
+                    balanceHits++
+                    return MockResponse().setResponseCode(401)
+                }
+                return MockResponse().setResponseCode(404)
+            }
+        }
+
+        val c = clientWithRefresh { _, _ -> }
+        val result = c.fetchBalance(account(ConnectionType.XIAOMI_API), sessionWithPassport)
+
+        assertTrue(result is ProviderResult.Failure.AuthError)
+        // First attempt + exactly one retry after refresh.
+        assertEquals(2, balanceHits)
     }
 }

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiResponseParserTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiResponseParserTest.kt
@@ -6,21 +6,18 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.zhavoronkov.tokenpulse.model.ConnectionType
 import org.zhavoronkov.tokenpulse.model.ProviderResult
-import org.zhavoronkov.tokenpulse.settings.Account
 
 class XiaomiResponseParserTest {
 
     private val gson = Gson()
 
-    private fun account() = Account(
-        id = "test-account",
-        connectionType = ConnectionType.XIAOMI_API,
-        authType = ConnectionType.XIAOMI_API.defaultAuthType
-    )
-
     private fun json(raw: String): JsonObject = gson.fromJson(raw, JsonObject::class.java)
+
+    private fun creditsOf(part: XiaomiResponseParser.BalancePart) = part as XiaomiResponseParser.BalancePart.Credits
+    private fun tokensOf(part: XiaomiResponseParser.BalancePart) = part as XiaomiResponseParser.BalancePart.TokensPart
+    private fun failureOf(part: XiaomiResponseParser.BalancePart) =
+        (part as XiaomiResponseParser.BalancePart.Failure).error
 
     // ── parseApiBalance ──────────────────────────────────────────────
 
@@ -31,152 +28,119 @@ class XiaomiResponseParserTest {
         fun `parses full balance response`() {
             val body =
                 """{"code":0,"data":{"balance":"55.48","giftBalance":"10.00","cashBalance":"45.48","currency":"USD"}}"""
-            val result = XiaomiResponseParser.parseApiBalance(
-                json(body),
-                account()
-            )
+            val part = creditsOf(XiaomiResponseParser.parseApiBalance(json(body)))
 
-            assertTrue(result is ProviderResult.Success)
-            val snapshot = (result as ProviderResult.Success).snapshot
-            assertEquals("55.48", snapshot.balance.credits?.remaining?.toPlainString())
-            assertEquals(ConnectionType.XIAOMI_API, snapshot.connectionType)
-            assertEquals("USD", snapshot.metadata["currency"])
-            assertEquals("10.00", snapshot.metadata["giftBalance"])
-            assertEquals("45.48", snapshot.metadata["cashBalance"])
+            assertEquals("55.48", part.credits.remaining?.toPlainString())
+            assertEquals("USD", part.metadata["currency"])
+            assertEquals("10.00", part.metadata["giftBalance"])
+            assertEquals("45.48", part.metadata["cashBalance"])
         }
 
         @Test
         fun `defaults missing fields to zero and USD`() {
-            val result = XiaomiResponseParser.parseApiBalance(
-                json("""{"code":0,"data":{}}"""),
-                account()
-            )
+            val part = creditsOf(XiaomiResponseParser.parseApiBalance(json("""{"code":0,"data":{}}""")))
 
-            assertTrue(result is ProviderResult.Success)
-            val snapshot = (result as ProviderResult.Success).snapshot
-            assertEquals("0", snapshot.balance.credits?.remaining?.toPlainString())
-            assertEquals("USD", snapshot.metadata["currency"])
-            assertEquals("0", snapshot.metadata["giftBalance"])
-            assertEquals("0", snapshot.metadata["cashBalance"])
+            assertEquals("0", part.credits.remaining?.toPlainString())
+            assertEquals("USD", part.metadata["currency"])
+            assertEquals("0", part.metadata["giftBalance"])
+            assertEquals("0", part.metadata["cashBalance"])
         }
 
         @Test
         fun `handles null data`() {
-            val result = XiaomiResponseParser.parseApiBalance(
-                json("""{"code":0,"data":null}"""),
-                account()
-            )
+            val part = creditsOf(XiaomiResponseParser.parseApiBalance(json("""{"code":0,"data":null}""")))
 
-            assertTrue(result is ProviderResult.Success)
-            val snapshot = (result as ProviderResult.Success).snapshot
-            assertEquals("0", snapshot.balance.credits?.remaining?.toPlainString())
+            assertEquals("0", part.credits.remaining?.toPlainString())
         }
 
         @Test
         fun `handles missing data field`() {
-            val result = XiaomiResponseParser.parseApiBalance(
-                json("""{"code":0}"""),
-                account()
-            )
+            val part = creditsOf(XiaomiResponseParser.parseApiBalance(json("""{"code":0}""")))
 
-            assertTrue(result is ProviderResult.Success)
-            val snapshot = (result as ProviderResult.Success).snapshot
-            assertEquals("0", snapshot.balance.credits?.remaining?.toPlainString())
+            assertEquals("0", part.credits.remaining?.toPlainString())
         }
 
         @Test
         fun `returns AuthError for token expired message`() {
-            val result = XiaomiResponseParser.parseApiBalance(
-                json("""{"code":-1,"message":"Token expired"}"""),
-                account()
-            )
+            val error =
+                failureOf(XiaomiResponseParser.parseApiBalance(json("""{"code":-1,"message":"Token expired"}""")))
 
-            assertTrue(result is ProviderResult.Failure.AuthError)
+            assertTrue(error is ProviderResult.Failure.AuthError)
             assertEquals(
                 "Xiaomi API error: Token expired",
-                (result as ProviderResult.Failure.AuthError).message
+                (error as ProviderResult.Failure.AuthError).message
             )
         }
 
         @Test
         fun `returns AuthError for session message`() {
-            val result = XiaomiResponseParser.parseApiBalance(
-                json("""{"code":-1,"message":"Session timeout"}"""),
-                account()
-            )
+            val error =
+                failureOf(XiaomiResponseParser.parseApiBalance(json("""{"code":-1,"message":"Session timeout"}""")))
 
-            assertTrue(result is ProviderResult.Failure.AuthError)
+            assertTrue(error is ProviderResult.Failure.AuthError)
         }
 
         @Test
         fun `returns AuthError for unauthorized message`() {
-            val result = XiaomiResponseParser.parseApiBalance(
-                json("""{"code":-1,"message":"Unauthorized access"}"""),
-                account()
+            val error = failureOf(
+                XiaomiResponseParser.parseApiBalance(json("""{"code":-1,"message":"Unauthorized access"}"""))
             )
 
-            assertTrue(result is ProviderResult.Failure.AuthError)
+            assertTrue(error is ProviderResult.Failure.AuthError)
         }
 
         @Test
         fun `returns AuthError for login message`() {
-            val result = XiaomiResponseParser.parseApiBalance(
-                json("""{"code":-1,"message":"Please login again"}"""),
-                account()
+            val error = failureOf(
+                XiaomiResponseParser.parseApiBalance(json("""{"code":-1,"message":"Please login again"}"""))
             )
 
-            assertTrue(result is ProviderResult.Failure.AuthError)
+            assertTrue(error is ProviderResult.Failure.AuthError)
         }
 
         @Test
         fun `returns RateLimited for rate message`() {
-            val result = XiaomiResponseParser.parseApiBalance(
-                json("""{"code":-1,"message":"Rate limit exceeded"}"""),
-                account()
+            val error = failureOf(
+                XiaomiResponseParser.parseApiBalance(json("""{"code":-1,"message":"Rate limit exceeded"}"""))
             )
 
-            assertTrue(result is ProviderResult.Failure.RateLimited)
+            assertTrue(error is ProviderResult.Failure.RateLimited)
             assertEquals(
                 "Xiaomi rate limit: Rate limit exceeded",
-                (result as ProviderResult.Failure.RateLimited).message
+                (error as ProviderResult.Failure.RateLimited).message
             )
         }
 
         @Test
         fun `returns RateLimited for throttle message`() {
-            val result = XiaomiResponseParser.parseApiBalance(
-                json("""{"code":-1,"message":"Throttled"}"""),
-                account()
+            val error = failureOf(
+                XiaomiResponseParser.parseApiBalance(json("""{"code":-1,"message":"Throttled"}"""))
             )
 
-            assertTrue(result is ProviderResult.Failure.RateLimited)
+            assertTrue(error is ProviderResult.Failure.RateLimited)
         }
 
         @Test
         fun `returns UnknownError for unrecognized error`() {
-            val result = XiaomiResponseParser.parseApiBalance(
-                json("""{"code":-1,"message":"Something went wrong"}"""),
-                account()
+            val error = failureOf(
+                XiaomiResponseParser.parseApiBalance(json("""{"code":-1,"message":"Something went wrong"}"""))
             )
 
-            assertTrue(result is ProviderResult.Failure.UnknownError)
+            assertTrue(error is ProviderResult.Failure.UnknownError)
             assertEquals(
                 "Xiaomi API error (code=-1): Something went wrong",
-                (result as ProviderResult.Failure.UnknownError).message
+                (error as ProviderResult.Failure.UnknownError).message
             )
         }
 
         @Test
         fun `returns UnknownError with default message when message is missing`() {
-            val result = XiaomiResponseParser.parseApiBalance(
-                json("""{"code":-1}"""),
-                account()
-            )
+            val error = failureOf(XiaomiResponseParser.parseApiBalance(json("""{"code":-1}""")))
 
-            assertTrue(result is ProviderResult.Failure.UnknownError)
+            assertTrue(error is ProviderResult.Failure.UnknownError)
             assertEquals(
                 "Xiaomi API error (code=-1): Unknown error",
-                (result as ProviderResult.Failure.UnknownError).message
+                (error as ProviderResult.Failure.UnknownError).message
             )
         }
     }
@@ -190,197 +154,164 @@ class XiaomiResponseParserTest {
         fun `parses full token plan response`() {
             val body =
                 """{"code":0,"data":{"monthUsage":{"percent":0.248,"items":[{"used":2727524596,"limit":11000000000}]}}}"""
-            val result = XiaomiResponseParser.parseTokenPlanUsage(
-                json(body),
-                account()
-            )
+            val part = tokensOf(XiaomiResponseParser.parseTokenPlanUsage(json(body)))
 
-            assertTrue(result is ProviderResult.Success)
-            val snapshot = (result as ProviderResult.Success).snapshot
-            assertEquals(ConnectionType.XIAOMI_TOKEN_PLAN, snapshot.connectionType)
-            assertEquals(2727524596L, snapshot.balance.tokens?.used)
-            assertEquals(11000000000L, snapshot.balance.tokens?.total)
-            assertEquals(8272475404L, snapshot.balance.tokens?.remaining)
-            assertEquals("active", snapshot.metadata["planStatus"])
+            assertEquals(2727524596L, part.tokens.used)
+            assertEquals(11000000000L, part.tokens.total)
+            assertEquals(8272475404L, part.tokens.remaining)
+            assertEquals("active", part.metadata["planStatus"])
             // 0.248 * 100 = 24 (int truncation)
-            assertEquals("24", snapshot.metadata["sessionUsed"])
+            assertEquals("24", part.metadata["sessionUsed"])
         }
 
         @Test
         fun `handles null data`() {
-            val result = XiaomiResponseParser.parseTokenPlanUsage(
-                json("""{"code":0,"data":null}"""),
-                account()
-            )
+            val part = tokensOf(XiaomiResponseParser.parseTokenPlanUsage(json("""{"code":0,"data":null}""")))
 
-            assertTrue(result is ProviderResult.Success)
-            val snapshot = (result as ProviderResult.Success).snapshot
-            assertEquals(0L, snapshot.balance.tokens?.used)
-            assertEquals(0L, snapshot.balance.tokens?.total)
-            assertEquals(0L, snapshot.balance.tokens?.remaining)
-            assertEquals("100", snapshot.metadata["sessionUsed"])
-            assertEquals("inactive", snapshot.metadata["planStatus"])
+            assertEquals(0L, part.tokens.used)
+            assertEquals(0L, part.tokens.total)
+            assertEquals(0L, part.tokens.remaining)
+            assertEquals("100", part.metadata["sessionUsed"])
+            assertEquals("inactive", part.metadata["planStatus"])
         }
 
         @Test
         fun `handles missing data field`() {
-            val result = XiaomiResponseParser.parseTokenPlanUsage(
-                json("""{"code":0}"""),
-                account()
-            )
+            val part = tokensOf(XiaomiResponseParser.parseTokenPlanUsage(json("""{"code":0}""")))
 
-            assertTrue(result is ProviderResult.Success)
-            val snapshot = (result as ProviderResult.Success).snapshot
-            assertEquals(0L, snapshot.balance.tokens?.total)
-            assertEquals("inactive", snapshot.metadata["planStatus"])
+            assertEquals(0L, part.tokens.total)
+            assertEquals("inactive", part.metadata["planStatus"])
         }
 
         @Test
         fun `handles null monthUsage`() {
-            val result = XiaomiResponseParser.parseTokenPlanUsage(
-                json("""{"code":0,"data":{"monthUsage":null}}"""),
-                account()
+            val part = tokensOf(
+                XiaomiResponseParser.parseTokenPlanUsage(json("""{"code":0,"data":{"monthUsage":null}}"""))
             )
 
-            assertTrue(result is ProviderResult.Success)
-            val snapshot = (result as ProviderResult.Success).snapshot
-            assertEquals(0L, snapshot.balance.tokens?.total)
-            assertEquals("100", snapshot.metadata["sessionUsed"])
-            assertEquals("inactive", snapshot.metadata["planStatus"])
+            assertEquals(0L, part.tokens.total)
+            assertEquals("100", part.metadata["sessionUsed"])
+            assertEquals("inactive", part.metadata["planStatus"])
         }
 
         @Test
         fun `handles missing monthUsage field`() {
-            val result = XiaomiResponseParser.parseTokenPlanUsage(
-                json("""{"code":0,"data":{}}"""),
-                account()
-            )
+            val part = tokensOf(XiaomiResponseParser.parseTokenPlanUsage(json("""{"code":0,"data":{}}""")))
 
-            assertTrue(result is ProviderResult.Success)
-            val snapshot = (result as ProviderResult.Success).snapshot
-            assertEquals(0L, snapshot.balance.tokens?.total)
-            assertEquals("inactive", snapshot.metadata["planStatus"])
+            assertEquals(0L, part.tokens.total)
+            assertEquals("inactive", part.metadata["planStatus"])
         }
 
         @Test
         fun `handles null items array`() {
-            val result = XiaomiResponseParser.parseTokenPlanUsage(
-                json("""{"code":0,"data":{"monthUsage":{"percent":0.5,"items":null}}}"""),
-                account()
+            val part = tokensOf(
+                XiaomiResponseParser.parseTokenPlanUsage(
+                    json("""{"code":0,"data":{"monthUsage":{"percent":0.5,"items":null}}}""")
+                )
             )
 
-            assertTrue(result is ProviderResult.Success)
-            val snapshot = (result as ProviderResult.Success).snapshot
-            assertEquals(0L, snapshot.balance.tokens?.used)
-            assertEquals(0L, snapshot.balance.tokens?.total)
-            assertEquals("100", snapshot.metadata["sessionUsed"])
-            assertEquals("inactive", snapshot.metadata["planStatus"])
+            assertEquals(0L, part.tokens.used)
+            assertEquals(0L, part.tokens.total)
+            assertEquals("100", part.metadata["sessionUsed"])
+            assertEquals("inactive", part.metadata["planStatus"])
         }
 
         @Test
         fun `handles empty items array`() {
-            val result = XiaomiResponseParser.parseTokenPlanUsage(
-                json("""{"code":0,"data":{"monthUsage":{"percent":0.5,"items":[]}}}"""),
-                account()
+            val part = tokensOf(
+                XiaomiResponseParser.parseTokenPlanUsage(
+                    json("""{"code":0,"data":{"monthUsage":{"percent":0.5,"items":[]}}}""")
+                )
             )
 
-            assertTrue(result is ProviderResult.Success)
-            val snapshot = (result as ProviderResult.Success).snapshot
-            assertEquals(0L, snapshot.balance.tokens?.used)
-            assertEquals(0L, snapshot.balance.tokens?.total)
-            assertEquals("100", snapshot.metadata["sessionUsed"])
-            assertEquals("inactive", snapshot.metadata["planStatus"])
+            assertEquals(0L, part.tokens.used)
+            assertEquals(0L, part.tokens.total)
+            assertEquals("100", part.metadata["sessionUsed"])
+            assertEquals("inactive", part.metadata["planStatus"])
         }
 
         @Test
         fun `handles missing items field`() {
-            val result = XiaomiResponseParser.parseTokenPlanUsage(
-                json("""{"code":0,"data":{"monthUsage":{"percent":0.5}}}"""),
-                account()
+            val part = tokensOf(
+                XiaomiResponseParser.parseTokenPlanUsage(
+                    json("""{"code":0,"data":{"monthUsage":{"percent":0.5}}}""")
+                )
             )
 
-            assertTrue(result is ProviderResult.Success)
-            val snapshot = (result as ProviderResult.Success).snapshot
-            assertEquals(0L, snapshot.balance.tokens?.total)
-            assertEquals("inactive", snapshot.metadata["planStatus"])
+            assertEquals(0L, part.tokens.total)
+            assertEquals("inactive", part.metadata["planStatus"])
         }
 
         @Test
         fun `handles missing percent field`() {
-            val result = XiaomiResponseParser.parseTokenPlanUsage(
-                json("""{"code":0,"data":{"monthUsage":{"items":[{"used":100,"limit":200}]}}}"""),
-                account()
+            val part = tokensOf(
+                XiaomiResponseParser.parseTokenPlanUsage(
+                    json("""{"code":0,"data":{"monthUsage":{"items":[{"used":100,"limit":200}]}}}""")
+                )
             )
 
-            assertTrue(result is ProviderResult.Success)
-            val snapshot = (result as ProviderResult.Success).snapshot
-            assertEquals(100L, snapshot.balance.tokens?.used)
-            assertEquals(200L, snapshot.balance.tokens?.total)
-            assertEquals("active", snapshot.metadata["planStatus"])
+            assertEquals(100L, part.tokens.used)
+            assertEquals(200L, part.tokens.total)
+            assertEquals("active", part.metadata["planStatus"])
             // percent defaults to 0.0 → 0 * 100 = 0
-            assertEquals("0", snapshot.metadata["sessionUsed"])
+            assertEquals("0", part.metadata["sessionUsed"])
         }
 
         @Test
         fun `reports inactive plan when totalCredits is zero`() {
-            val result = XiaomiResponseParser.parseTokenPlanUsage(
-                json("""{"code":0,"data":{"monthUsage":{"percent":0.0,"items":[{"used":0,"limit":0}]}}}"""),
-                account()
+            val part = tokensOf(
+                XiaomiResponseParser.parseTokenPlanUsage(
+                    json("""{"code":0,"data":{"monthUsage":{"percent":0.0,"items":[{"used":0,"limit":0}]}}}""")
+                )
             )
 
-            assertTrue(result is ProviderResult.Success)
-            val snapshot = (result as ProviderResult.Success).snapshot
-            assertEquals("inactive", snapshot.metadata["planStatus"])
-            assertEquals("100", snapshot.metadata["sessionUsed"])
+            assertEquals("inactive", part.metadata["planStatus"])
+            assertEquals("100", part.metadata["sessionUsed"])
         }
 
         @Test
         fun `reports active plan when totalCredits is positive`() {
-            val result = XiaomiResponseParser.parseTokenPlanUsage(
-                json("""{"code":0,"data":{"monthUsage":{"percent":0.75,"items":[{"used":750,"limit":1000}]}}}"""),
-                account()
+            val part = tokensOf(
+                XiaomiResponseParser.parseTokenPlanUsage(
+                    json("""{"code":0,"data":{"monthUsage":{"percent":0.75,"items":[{"used":750,"limit":1000}]}}}""")
+                )
             )
 
-            assertTrue(result is ProviderResult.Success)
-            val snapshot = (result as ProviderResult.Success).snapshot
-            assertEquals("active", snapshot.metadata["planStatus"])
-            assertEquals("75", snapshot.metadata["sessionUsed"])
-            assertEquals(750L, snapshot.balance.tokens?.used)
-            assertEquals(1000L, snapshot.balance.tokens?.total)
-            assertEquals(250L, snapshot.balance.tokens?.remaining)
+            assertEquals("active", part.metadata["planStatus"])
+            assertEquals("75", part.metadata["sessionUsed"])
+            assertEquals(750L, part.tokens.used)
+            assertEquals(1000L, part.tokens.total)
+            assertEquals(250L, part.tokens.remaining)
         }
 
         @Test
         fun `returns AuthError for expired session`() {
-            val result = XiaomiResponseParser.parseTokenPlanUsage(
-                json("""{"code":-1,"message":"Token expired"}"""),
-                account()
+            val error = failureOf(
+                XiaomiResponseParser.parseTokenPlanUsage(json("""{"code":-1,"message":"Token expired"}"""))
             )
 
-            assertTrue(result is ProviderResult.Failure.AuthError)
+            assertTrue(error is ProviderResult.Failure.AuthError)
         }
 
         @Test
         fun `returns RateLimited for rate limit error`() {
-            val result = XiaomiResponseParser.parseTokenPlanUsage(
-                json("""{"code":-1,"message":"Rate limit exceeded"}"""),
-                account()
+            val error = failureOf(
+                XiaomiResponseParser.parseTokenPlanUsage(json("""{"code":-1,"message":"Rate limit exceeded"}"""))
             )
 
-            assertTrue(result is ProviderResult.Failure.RateLimited)
+            assertTrue(error is ProviderResult.Failure.RateLimited)
         }
 
         @Test
         fun `returns UnknownError for other errors`() {
-            val result = XiaomiResponseParser.parseTokenPlanUsage(
-                json("""{"code":500,"message":"Internal server error"}"""),
-                account()
+            val error = failureOf(
+                XiaomiResponseParser.parseTokenPlanUsage(json("""{"code":500,"message":"Internal server error"}"""))
             )
 
-            assertTrue(result is ProviderResult.Failure.UnknownError)
+            assertTrue(error is ProviderResult.Failure.UnknownError)
             assertEquals(
                 "Xiaomi API error (code=500): Internal server error",
-                (result as ProviderResult.Failure.UnknownError).message
+                (error as ProviderResult.Failure.UnknownError).message
             )
         }
     }

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiSessionRefresherTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiSessionRefresherTest.kt
@@ -147,8 +147,7 @@ class XiaomiSessionRefresherTest {
         dispatch(
             genLogin = MockResponse().setResponseCode(302)
                 .setHeader("Location", "https://account.xiaomi.com/pass/serviceLogin?sid=api-platform"),
-            serviceLogin = MockResponse().setResponseCode(200)
-                .setBody("&&&START&&&{\"ssecurity\":\"s\",\"location\":\"https://platform.xiaomimimo.com/sts?sign=z\"}"),
+            serviceLogin = MockResponse().setResponseCode(200).setBody(SERVICE_LOGIN_OK_BODY),
             sts = MockResponse().setResponseCode(302)
                 .addHeader("Set-Cookie", "some_other_cookie=abc; Path=/")
         )
@@ -173,8 +172,7 @@ class XiaomiSessionRefresherTest {
         dispatch(
             genLogin = MockResponse().setResponseCode(302)
                 .setHeader("Location", "https://account.xiaomi.com/pass/serviceLogin?sid=api-platform"),
-            serviceLogin = MockResponse().setResponseCode(200)
-                .setBody("&&&START&&&{\"ssecurity\":\"s\",\"location\":\"https://platform.xiaomimimo.com/sts?sign=z\"}"),
+            serviceLogin = MockResponse().setResponseCode(200).setBody(SERVICE_LOGIN_OK_BODY),
             sts = MockResponse().setResponseCode(200)
                 .addHeader("Set-Cookie", "api-platform_serviceToken=T; Path=/")
         )
@@ -192,5 +190,13 @@ class XiaomiSessionRefresherTest {
             }
         }
         assertEquals(true, sawServiceLogin)
+    }
+
+    private companion object {
+        // Passport-authenticated serviceLogin JSON reused across happy-path/probe tests.
+        // Kept as a constant to avoid ArgumentListWrapping detekt hits on the long inline literal.
+        const val SERVICE_LOGIN_OK_BODY =
+            "&&&START&&&{\"ssecurity\":\"s\"," +
+                "\"location\":\"https://platform.xiaomimimo.com/sts?sign=z\"}"
     }
 }

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiSessionRefresherTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/xiaomi/XiaomiSessionRefresherTest.kt
@@ -1,0 +1,196 @@
+package org.zhavoronkov.tokenpulse.provider.xiaomi
+
+import com.google.gson.Gson
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class XiaomiSessionRefresherTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var refresher: XiaomiSessionRefresher
+    private val gson = Gson()
+
+    private fun sessionWithPassport() = XiaomiProviderClient.XiaomiSession(
+        serviceToken = "old-token",
+        userId = "12345",
+        slh = "old-slh",
+        ph = "old-ph",
+        passToken = "pass-abc",
+        cUserId = "cuser-9"
+    )
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        val base = server.url("/").toString().removeSuffix("/")
+        refresher = XiaomiSessionRefresher(
+            httpClient = OkHttpClient(),
+            gson = gson,
+            platformBaseUrl = base,
+            accountBaseUrl = base
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    /**
+     * Route by path so the three-step chain (genLoginUrl -> serviceLogin -> sts) can
+     * be scripted independently against a single mock server.
+     */
+    private fun dispatch(
+        genLogin: MockResponse,
+        serviceLogin: MockResponse,
+        sts: MockResponse
+    ) {
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                val path = request.path ?: ""
+                return when {
+                    path.startsWith("/api/v1/genLoginUrl") -> genLogin
+                    path.startsWith("/pass/serviceLogin") -> serviceLogin
+                    path.startsWith("/sts") -> sts
+                    else -> MockResponse().setResponseCode(404)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `refresh happy path returns fresh session and preserves passport`() {
+        dispatch(
+            genLogin = MockResponse()
+                .setResponseCode(302)
+                .setHeader("Location", "https://account.xiaomi.com/pass/serviceLogin?sid=api-platform&_group=DEFAULT"),
+            serviceLogin = MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    "&&&START&&&{\"code\":0,\"ssecurity\":\"sec-xyz\"," +
+                        "\"location\":\"https://platform.xiaomimimo.com/sts?sign=abc&followup=x\"}"
+                ),
+            sts = MockResponse()
+                .setResponseCode(302)
+                .addHeader("Set-Cookie", "api-platform_serviceToken=NEW-TOKEN; Path=/; HttpOnly")
+                .addHeader("Set-Cookie", "api-platform_slh=NEW-SLH; Path=/")
+                .addHeader("Set-Cookie", "api-platform_ph=NEW-PH; Path=/")
+        )
+
+        val result = refresher.refresh(sessionWithPassport())
+
+        requireNotNull(result)
+        assertEquals("NEW-TOKEN", result.serviceToken)
+        assertEquals("NEW-SLH", result.slh)
+        assertEquals("NEW-PH", result.ph)
+        // Passport credentials preserved for the next refresh.
+        assertEquals("pass-abc", result.passToken)
+        assertEquals("12345", result.userId)
+        assertEquals("cuser-9", result.cUserId)
+    }
+
+    @Test
+    fun `refresh reads serviceLogin url from 200 json body location`() {
+        dispatch(
+            genLogin = MockResponse()
+                .setResponseCode(200)
+                .setBody("{\"location\":\"https://account.xiaomi.com/pass/serviceLogin?sid=api-platform\"}"),
+            serviceLogin = MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    "&&&START&&&{\"ssecurity\":\"s\",\"location\":\"https://platform.xiaomimimo.com/sts?sign=z\"}"
+                ),
+            sts = MockResponse()
+                .setResponseCode(200)
+                .addHeader("Set-Cookie", "api-platform_serviceToken=T2; Path=/")
+        )
+
+        val result = refresher.refresh(sessionWithPassport())
+
+        requireNotNull(result)
+        assertEquals("T2", result.serviceToken)
+    }
+
+    @Test
+    fun `refresh returns null when no passToken`() {
+        val result = refresher.refresh(
+            XiaomiProviderClient.XiaomiSession(serviceToken = "t", userId = "1", passToken = null)
+        )
+        assertNull(result)
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun `refresh returns null when serviceLogin lacks ssecurity`() {
+        dispatch(
+            genLogin = MockResponse().setResponseCode(302)
+                .setHeader("Location", "https://account.xiaomi.com/pass/serviceLogin?sid=api-platform"),
+            serviceLogin = MockResponse().setResponseCode(200)
+                .setBody("&&&START&&&{\"code\":70016,\"_sign\":\"needs-login\"}"),
+            sts = MockResponse().setResponseCode(200)
+        )
+
+        assertNull(refresher.refresh(sessionWithPassport()))
+    }
+
+    @Test
+    fun `refresh returns null when sts sets no serviceToken cookie`() {
+        dispatch(
+            genLogin = MockResponse().setResponseCode(302)
+                .setHeader("Location", "https://account.xiaomi.com/pass/serviceLogin?sid=api-platform"),
+            serviceLogin = MockResponse().setResponseCode(200)
+                .setBody("&&&START&&&{\"ssecurity\":\"s\",\"location\":\"https://platform.xiaomimimo.com/sts?sign=z\"}"),
+            sts = MockResponse().setResponseCode(302)
+                .addHeader("Set-Cookie", "some_other_cookie=abc; Path=/")
+        )
+
+        assertNull(refresher.refresh(sessionWithPassport()))
+    }
+
+    @Test
+    fun `refresh returns null on malformed serviceLogin body`() {
+        dispatch(
+            genLogin = MockResponse().setResponseCode(302)
+                .setHeader("Location", "https://account.xiaomi.com/pass/serviceLogin?sid=api-platform"),
+            serviceLogin = MockResponse().setResponseCode(200).setBody("not-json-at-all"),
+            sts = MockResponse().setResponseCode(200)
+        )
+
+        assertNull(refresher.refresh(sessionWithPassport()))
+    }
+
+    @Test
+    fun `refresh sends passport cookies to serviceLogin`() {
+        dispatch(
+            genLogin = MockResponse().setResponseCode(302)
+                .setHeader("Location", "https://account.xiaomi.com/pass/serviceLogin?sid=api-platform"),
+            serviceLogin = MockResponse().setResponseCode(200)
+                .setBody("&&&START&&&{\"ssecurity\":\"s\",\"location\":\"https://platform.xiaomimimo.com/sts?sign=z\"}"),
+            sts = MockResponse().setResponseCode(200)
+                .addHeader("Set-Cookie", "api-platform_serviceToken=T; Path=/")
+        )
+
+        refresher.refresh(sessionWithPassport())
+
+        var sawServiceLogin = false
+        repeat(server.requestCount) {
+            val recorded = server.takeRequest()
+            if ((recorded.path ?: "").startsWith("/pass/serviceLogin")) {
+                sawServiceLogin = true
+                val cookie = recorded.getHeader("Cookie") ?: ""
+                assertEquals(true, cookie.contains("passToken=pass-abc"))
+                assertEquals(true, cookie.contains("_json") || recorded.path!!.contains("_json=true"))
+            }
+        }
+        assertEquals(true, sawServiceLogin)
+    }
+}

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/settings/AccountTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/settings/AccountTest.kt
@@ -527,6 +527,36 @@ class SanitizeAccountsTest {
         val sanitized = accounts.sanitizeAccounts()
         assertEquals("user@ex.com • user@ex.com's Organization", sanitized[0].name)
     }
+
+    @Test
+    fun `sanitizeAccounts migrates legacy XIAOMI_API to unified XIAOMI with session auth`() {
+        val accounts = listOf(
+            Account(
+                connectionType = ConnectionType.XIAOMI_API,
+                authType = AuthType.XIAOMI_API_KEY
+            )
+        )
+
+        val sanitized = accounts.sanitizeAccounts()
+
+        assertEquals(ConnectionType.XIAOMI, sanitized[0].connectionType)
+        assertEquals(AuthType.XIAOMI_SESSION, sanitized[0].authType)
+    }
+
+    @Test
+    fun `sanitizeAccounts migrates legacy XIAOMI_TOKEN_PLAN to unified XIAOMI with session auth`() {
+        val accounts = listOf(
+            Account(
+                connectionType = ConnectionType.XIAOMI_TOKEN_PLAN,
+                authType = AuthType.XIAOMI_TOKEN_PLAN_KEY
+            )
+        )
+
+        val sanitized = accounts.sanitizeAccounts()
+
+        assertEquals(ConnectionType.XIAOMI, sanitized[0].connectionType)
+        assertEquals(AuthType.XIAOMI_SESSION, sanitized[0].authType)
+    }
 }
 
 /**

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/ui/BalanceFormatterTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/ui/BalanceFormatterTest.kt
@@ -661,21 +661,19 @@ class BalanceFormatterTest {
     // === isUsagePercentageType ===
 
     @Test
-    fun `isUsagePercentageType returns true for XIAOMI_TOKEN_PLAN`() {
-        assertEquals(true, BalanceFormatter.isUsagePercentageType(ConnectionType.XIAOMI_TOKEN_PLAN))
+    fun `isUsagePercentageType returns false for XIAOMI unified`() {
+        // The unified XIAOMI type prefers its dollar balance and only falls back
+        // to a Token Plan percentage at render time, so it is NOT a pure
+        // percentage type like Claude/Codex.
+        assertEquals(false, BalanceFormatter.isUsagePercentageType(ConnectionType.XIAOMI))
     }
 
-    @Test
-    fun `isUsagePercentageType returns false for XIAOMI_API`() {
-        assertEquals(false, BalanceFormatter.isUsagePercentageType(ConnectionType.XIAOMI_API))
-    }
-
-    // === formatUsagePercentageForStatusBar for XIAOMI_TOKEN_PLAN ===
+    // === formatUsagePercentageForStatusBar for unified XIAOMI (Token Plan slice) ===
 
     @Test
-    fun `formatUsagePercentageForStatusBar shows percentage for XIAOMI_TOKEN_PLAN`() {
+    fun `formatUsagePercentageForStatusBar shows percentage for XIAOMI`() {
         val result = successResult(
-            connectionType = ConnectionType.XIAOMI_TOKEN_PLAN,
+            connectionType = ConnectionType.XIAOMI,
             metadata = mapOf("sessionUsed" to "25")
         )
         val formatted = BalanceFormatter.formatUsagePercentageForStatusBar(
@@ -686,9 +684,9 @@ class BalanceFormatterTest {
     }
 
     @Test
-    fun `formatUsagePercentageForStatusBar shows descriptive percentage for XIAOMI_TOKEN_PLAN`() {
+    fun `formatUsagePercentageForStatusBar shows descriptive percentage for XIAOMI`() {
         val result = successResult(
-            connectionType = ConnectionType.XIAOMI_TOKEN_PLAN,
+            connectionType = ConnectionType.XIAOMI,
             metadata = mapOf("sessionUsed" to "25")
         )
         val formatted = BalanceFormatter.formatUsagePercentageForStatusBar(
@@ -699,9 +697,9 @@ class BalanceFormatterTest {
     }
 
     @Test
-    fun `formatUsagePercentageForStatusBar shows used of remaining for XIAOMI_TOKEN_PLAN`() {
+    fun `formatUsagePercentageForStatusBar shows used of remaining for XIAOMI`() {
         val result = successResult(
-            connectionType = ConnectionType.XIAOMI_TOKEN_PLAN,
+            connectionType = ConnectionType.XIAOMI,
             balance = Balance(tokens = Tokens(used = 2727524596, total = 11000000000, remaining = 8272475404)),
             metadata = mapOf("sessionUsed" to "25")
         )
@@ -715,9 +713,9 @@ class BalanceFormatterTest {
     }
 
     @Test
-    fun `formatUsagePercentageForStatusBar shows descriptive used of remaining for XIAOMI_TOKEN_PLAN`() {
+    fun `formatUsagePercentageForStatusBar shows descriptive used of remaining for XIAOMI`() {
         val result = successResult(
-            connectionType = ConnectionType.XIAOMI_TOKEN_PLAN,
+            connectionType = ConnectionType.XIAOMI,
             balance = Balance(tokens = Tokens(used = 2727524596, total = 11000000000, remaining = 8272475404)),
             metadata = mapOf("sessionUsed" to "25")
         )
@@ -731,9 +729,9 @@ class BalanceFormatterTest {
     }
 
     @Test
-    fun `formatUsagePercentageForStatusBar shows remaining only for XIAOMI_TOKEN_PLAN`() {
+    fun `formatUsagePercentageForStatusBar shows remaining only for XIAOMI`() {
         val result = successResult(
-            connectionType = ConnectionType.XIAOMI_TOKEN_PLAN,
+            connectionType = ConnectionType.XIAOMI,
             balance = Balance(tokens = Tokens(used = 2727524596, total = 11000000000, remaining = 8272475404)),
             metadata = mapOf("sessionUsed" to "25")
         )
@@ -747,9 +745,9 @@ class BalanceFormatterTest {
     }
 
     @Test
-    fun `formatUsagePercentageForStatusBar shows descriptive remaining only for XIAOMI_TOKEN_PLAN`() {
+    fun `formatUsagePercentageForStatusBar shows descriptive remaining only for XIAOMI`() {
         val result = successResult(
-            connectionType = ConnectionType.XIAOMI_TOKEN_PLAN,
+            connectionType = ConnectionType.XIAOMI,
             balance = Balance(tokens = Tokens(used = 2727524596, total = 11000000000, remaining = 8272475404)),
             metadata = mapOf("sessionUsed" to "25")
         )
@@ -787,12 +785,25 @@ class BalanceFormatterTest {
         assertEquals("$200 of $393 remaining", formatted)
     }
 
-    // === getStatusBarDataFromSnapshot for XIAOMI_TOKEN_PLAN ===
+    // === getStatusBarDataFromSnapshot for unified XIAOMI ===
 
     @Test
-    fun `returns UsagePercentage for XIAOMI_TOKEN_PLAN connection`() {
-        val snap = snapshot(ConnectionType.XIAOMI_TOKEN_PLAN)
+    fun `returns UsagePercentage for XIAOMI when only Token Plan tokens present`() {
+        val snap = snapshot(
+            ConnectionType.XIAOMI,
+            balance = Balance(tokens = Tokens(used = 100, total = 1000, remaining = 900))
+        )
         val data = BalanceFormatter.getStatusBarDataFromSnapshot(snap)
         assert(data is BalanceFormatter.StatusBarData.UsagePercentage)
+    }
+
+    @Test
+    fun `returns RemainingDollars for XIAOMI when dollar balance present`() {
+        val snap = snapshot(
+            ConnectionType.XIAOMI,
+            balance = Balance(credits = Credits(remaining = BigDecimal("12.34")))
+        )
+        val data = BalanceFormatter.getStatusBarDataFromSnapshot(snap)
+        assert(data is BalanceFormatter.StatusBarData.RemainingDollars)
     }
 }

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/ui/TooltipModelTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/ui/TooltipModelTest.kt
@@ -278,25 +278,38 @@ class TooltipModelTest {
         assertTrue(out.contains(TooltipRow.Info("Status: ok")))
     }
 
-    // ---- Xiaomi Token Plan ------------------------------------------------
+    // ---- Xiaomi (unified: dollar balance + Token Plan) --------------------
 
     @Test
-    fun `xiaomi empty metadata and no tokens yields no rows`() {
-        // snapshot.metadata is a non-null empty map, so the (metadata == null
-        // && tokens == null) guard is false; nothing is emitted.
-        val r = success(ConnectionType.XIAOMI_TOKEN_PLAN)
-        assertTrue(rows(ConnectionType.XIAOMI_TOKEN_PLAN, r).isEmpty())
+    fun `xiaomi empty metadata and no balance yields no usage data`() {
+        val r = success(ConnectionType.XIAOMI)
+        val out = rows(ConnectionType.XIAOMI, r)
+        assertEquals(listOf(TooltipRow.Info("No usage data")), out)
     }
 
     @Test
     fun `xiaomi session used yields credits bar and plan used`() {
         val r = success(
-            ConnectionType.XIAOMI_TOKEN_PLAN,
+            ConnectionType.XIAOMI,
             tokens = Tokens(total = 1000, used = 250),
             metadata = mapOf("sessionUsed" to "40"),
         )
-        val out = rows(ConnectionType.XIAOMI_TOKEN_PLAN, r)
+        val out = rows(ConnectionType.XIAOMI, r)
         assertEquals(TooltipRow.BalanceBar("Credits", 60), out[0])
+        assertTrue(out.any { it is TooltipRow.LabelValue && it.label == "Used:" })
+    }
+
+    @Test
+    fun `xiaomi dollar balance renders Balance row above Token Plan block`() {
+        val r = success(
+            ConnectionType.XIAOMI,
+            credits = Credits(remaining = BigDecimal("55.48")),
+            tokens = Tokens(total = 1000, used = 250),
+            metadata = mapOf("sessionUsed" to "40"),
+        )
+        val out = rows(ConnectionType.XIAOMI, r)
+        assertEquals(TooltipRow.LabelValue("Balance:", "$55.48", bold = true), out[0])
+        assertTrue(out.any { it is TooltipRow.BalanceBar && it.label == "Credits" })
         assertTrue(out.any { it is TooltipRow.LabelValue && it.label == "Used:" })
     }
 

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/ui/XiaomiCookieHarvestTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/ui/XiaomiCookieHarvestTest.kt
@@ -1,0 +1,122 @@
+package org.zhavoronkov.tokenpulse.ui
+
+import com.google.gson.JsonParser
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for the pure cookie-map -> session-JSON mapping used by the JCEF login
+ * flow. Kept off the JCEF path so it can run headless without an IDE fixture.
+ */
+class XiaomiCookieHarvestTest {
+
+    @Test
+    fun `buildSessionCookies extracts all six fields from platform+passport maps`() {
+        val platform = mapOf(
+            "api-platform_serviceToken" to "st-abc",
+            "userId" to "1555143730",
+            "api-platform_slh" to "slh-xyz",
+            "api-platform_ph" to "ph-xyz"
+        )
+        val passport = mapOf(
+            "passToken" to "V1:secretPass",
+            "userId" to "1555143730",
+            "cUserId" to "cuser-abc"
+        )
+
+        val cookies = XiaomiCookieHarvest.buildSessionCookies(platform, passport)
+
+        assertNotNull(cookies)
+        assertEquals("st-abc", cookies!!.serviceToken)
+        assertEquals("1555143730", cookies.userId)
+        assertEquals("slh-xyz", cookies.slh)
+        assertEquals("ph-xyz", cookies.ph)
+        assertEquals("V1:secretPass", cookies.passToken)
+        assertEquals("cuser-abc", cookies.cUserId)
+        assertTrue(XiaomiCookieHarvest.hasRefreshableSession(cookies))
+    }
+
+    @Test
+    fun `buildSessionCookies returns null when serviceToken is missing`() {
+        val platform = mapOf("userId" to "1555143730")
+        assertNull(XiaomiCookieHarvest.buildSessionCookies(platform, emptyMap()))
+    }
+
+    @Test
+    fun `buildSessionCookies returns null when userId is missing on both hosts`() {
+        val platform = mapOf("api-platform_serviceToken" to "st-abc")
+        assertNull(XiaomiCookieHarvest.buildSessionCookies(platform, emptyMap()))
+    }
+
+    @Test
+    fun `buildSessionCookies falls back to passport userId when platform userId is absent`() {
+        val platform = mapOf("api-platform_serviceToken" to "st-abc")
+        val passport = mapOf(
+            "userId" to "1555143730",
+            "passToken" to "V1:x"
+        )
+        val cookies = XiaomiCookieHarvest.buildSessionCookies(platform, passport)
+        assertNotNull(cookies)
+        assertEquals("1555143730", cookies!!.userId)
+    }
+
+    @Test
+    fun `buildSessionCookies without passport still yields a usable session (no auto-refresh)`() {
+        val platform = mapOf(
+            "api-platform_serviceToken" to "st-abc",
+            "userId" to "1555143730"
+        )
+        val cookies = XiaomiCookieHarvest.buildSessionCookies(platform, emptyMap())
+        assertNotNull(cookies)
+        assertNull(cookies!!.passToken)
+        assertFalse(XiaomiCookieHarvest.hasRefreshableSession(cookies))
+    }
+
+    @Test
+    fun `buildSessionCookies treats blank cookie values as absent`() {
+        val platform = mapOf(
+            "api-platform_serviceToken" to "",
+            "userId" to "1555143730"
+        )
+        assertNull(XiaomiCookieHarvest.buildSessionCookies(platform, emptyMap()))
+    }
+
+    @Test
+    fun `buildSessionJson produces JSON with the expected field names`() {
+        val platform = mapOf(
+            "api-platform_serviceToken" to "st-abc",
+            "userId" to "1555143730"
+        )
+        val json = XiaomiCookieHarvest.buildSessionJson(platform, emptyMap())
+        assertNotNull(json)
+        val obj = JsonParser.parseString(json).asJsonObject
+        assertEquals("st-abc", obj["serviceToken"].asString)
+        assertEquals("1555143730", obj["userId"].asString)
+        // Optional fields are omitted rather than serialized as null.
+        assertFalse(obj.has("slh"))
+        assertFalse(obj.has("passToken"))
+    }
+
+    @Test
+    fun `buildSessionJson JSON round-trips into XiaomiSessionCookies`() {
+        val platform = mapOf(
+            "api-platform_serviceToken" to "st-abc",
+            "userId" to "1555143730",
+            "api-platform_slh" to "slh-xyz",
+            "api-platform_ph" to "ph-xyz"
+        )
+        val passport = mapOf(
+            "passToken" to "V1:secretPass",
+            "cUserId" to "cuser-abc"
+        )
+        val json = XiaomiCookieHarvest.buildSessionJson(platform, passport)!!
+        val parsed = com.google.gson.Gson().fromJson(json, XiaomiConnectDialog.XiaomiSessionCookies::class.java)
+        assertEquals("st-abc", parsed.serviceToken)
+        assertEquals("V1:secretPass", parsed.passToken)
+        assertEquals("cuser-abc", parsed.cUserId)
+    }
+}


### PR DESCRIPTION
## Summary

Two related capabilities on one branch for the Xiaomi MiMo provider:

1. **Silent session refresh** — headless re-login using the long-lived Xiaomi Passport cookie so the plugin stops asking users to re-paste a cURL every day.
2. **Unified provider** — the two previous connection types (pay-as-you-go **API** and **Token Plan**) are collapsed into a single `ConnectionType.XIAOMI` that surfaces both a dollar balance and Token Plan Credits from the same captured session, with a one-time migration for existing accounts.

## 1. Silent cookie refresh

**Problem.** Xiaomi platform session cookies (`api-platform_serviceToken`, `_slh`, `_ph`) expire after ~1 day, forcing manual reconnect. The browser avoids this because it also holds a long-lived Xiaomi Passport cookie (`passToken`) on `account.xiaomi.com` that silently re-mints the platform session via `genLoginUrl` -> `serviceLogin` -> `/sts`. The plugin only captured platform cookies, so it had nothing to re-mint with.

**Root cause (verified from HAR + two OSS Passport implementations).**

1. `GET /api/v1/genLoginUrl?currentPath=/console/balance` -> 302 to `account.xiaomi.com/pass/serviceLogin?callback=<platform.xiaomimimo.com/sts?sign=...>&sid=api-platform`.
2. `GET account.xiaomi.com/pass/serviceLogin?...&_json=true` with `passToken` -> body prefixed `&&&START&&&` then JSON containing `location` and `ssecurity`.
3. `GET` the returned `/sts?sign=...` -> `Set-Cookie` carries a fresh `api-platform_serviceToken` (+ `_slh`, `_ph`).

**Changes.**

- **`XiaomiSessionRefresher`** (new): drives the 3-step chain with `followRedirects(false)`; rehosts absolute Xiaomi URLs onto injected base URLs for testability.
- **`XiaomiSession`**: adds nullable `passToken` and `cUserId` (backward compatible; old blobs simply can't auto-refresh).
- **`XiaomiProviderClient`**: single silent-refresh gate shared across both endpoints (see part 2) on `401`/`403` or HTML login-page body; persists the refreshed session via an injected `sessionWriter` (Claude write-back precedent).
- **`XiaomiConnectDialog`** / one-click JCEF sign-in: captures the passport cookies alongside the platform cookies; warns when `passToken` is absent that auto-refresh is disabled.
- Reactive-only (no proactive schedule) per user decision.

## 2. Unified Xiaomi provider

**Problem.** The pay-as-you-go and Token Plan cases were modelled as two `ConnectionType`s that shared the same login. A user could have two accounts for the same Xiaomi identity; the balance client never used the `sk-`/`tp-` "API key" (it's inference-only) so the extra type only added confusion.

**Changes.**

- **`ConnectionType.XIAOMI`** (new, `displayName = "MiMo"`, `defaultAuthType = XIAOMI_SESSION`) is the single user-selectable Xiaomi type. `XIAOMI_API` and `XIAOMI_TOKEN_PLAN` remain in the enum but with `isAvailable=false` — kept only so old `tokenpulse.xml` entries still deserialize under XStream. Deleting them would break load-time deserialization.
- **`AuthType.XIAOMI_SESSION`** (new). Session-only; the sk-/tp- key field is hidden.
- **`XiaomiResponseParser`** now returns a `BalancePart` (Credits / TokensPart / Failure) so the client can compose slices from both endpoints.
- **`XiaomiProviderClient.fetchMerged`** queries `/api/v1/balance` and `/api/v1/tokenPlan/usage` on every fetch, composes one `BalanceSnapshot(connectionType=XIAOMI, balance=Balance(credits, tokens))` with merged metadata, and applies the silent-refresh gate across both endpoints — retrying only the endpoint(s) that actually failed with auth, once, after refresh.
- **Migration in two parts.**
  - Synchronous, in `sanitizeAccounts`: legacy `XIAOMI_API` / `XIAOMI_TOKEN_PLAN` are remapped to `XIAOMI` (authType flows to `XIAOMI_SESSION` via `normalizeConnectionAuthTypes`). No secret rewrite: the stored blob is already the session JSON keyed by `account.id`.
  - Async, in `BalanceRefreshService.dedupeXiaomiAccounts` on the IO scope, guarded by `TokenPulseSettings.xiaomiDedupeDone` so it runs once: group unified-XIAOMI accounts by their session `userId`, keep a deterministic survivor (passToken-capable, lowest id), and remove losers + their PasswordSafe secrets. **Data-loss guard**: accounts whose session is missing / unparseable / has a blank userId are left untouched (never merged). Runs before the first refresh.
- **Status bar** prefers the pay-as-you-go dollar balance (`RemainingDollars`) and falls back to Token Plan usage (`UsagePercentage`) when only tokens are present.
- **Tooltip** renders BOTH a `Balance:` row (dollars) AND the Token Plan block (`Credits` progress bar + `Used: x / y`), showing whichever parts exist.
- **`AccountEditDialog`** collapses to one Xiaomi option; XIAOMI is in `SESSION_BASED_TYPES` so the key field stays hidden.

## Tests

`./gradlew test detekt` — **BUILD SUCCESSFUL, 718 tests, 0 failures**, no detekt findings.

New / rewritten coverage worth calling out:

- **`XiaomiResponseParserTest`** — all 25 tests migrated to assert on the new `BalancePart.Credits` / `TokensPart` / `Failure` shape (Credits/Tokens values and metadata keys unchanged).
- **`XiaomiProviderClientTest`** — MockWebServer now uses a per-path `Dispatcher` (both endpoints are hit on every fetch). Adds a merged-snapshot test. Silent-refresh tests verify: refresh-once + `sessionWriter` persists the new token; retry ONLY the failed endpoint(s); no-refresh-without-passToken; HTML-login-body -> `AuthError` (not `ParseError`); single-retry cap when refresh doesn't fix expiry.
- **`BalanceFormatterTest` / `TooltipModelTest`** — retargeted to `XIAOMI`; encode `isUsagePercentageType(XIAOMI)==false`, dollar-first-else-tokens routing, and the both-blocks tooltip.
- **`AccountTest`** — new tests asserting `XIAOMI_API` and `XIAOMI_TOKEN_PLAN` both migrate to `XIAOMI` + `XIAOMI_SESSION` through `sanitizeAccounts()`.

## Migration / risk notes

- **XStream deserialization** of removed enum values is the top risk — mitigated by keeping the legacy constants in the enum (hidden). Do not delete them.
- **Async dedup** never deletes an account whose userId can't be read; runs once via the persisted flag.
- **Partial-endpoint failure** never masks a real total-auth failure: `AuthError` is only returned when both endpoints failed with auth after the refresh attempt; otherwise the successful part is returned and the other's non-auth failure is dropped so the balance we do have still surfaces.
- `passToken` is long-lived and sensitive; stored the same way as today's session, in PasswordSafe.
- Bot-detection on `platform.xiaomimimo.com` for non-browser clients is unverified; if it blocks us the flow degrades cleanly to today's "please reconnect" `AuthError`.