### PR TITLE
feat(nebius): silent CSRF session auto-refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Nebius session auto-refresh** — silently re-mints the CSRF token when it rotates (the most
+  common auth failure) by re-fetching the SPA landing page and scraping the fresh `csrfToken`,
+  so a still-valid session keeps working without reconnecting.
 - **Rich status-bar tooltip** — hovering the status-bar widget now shows a native Swing popup
   with real progress bars for each provider/account, replacing the old HTML tooltip; theme-aware
   colors and screen-clamped positioning so it always fits on screen.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ The **"Connect Billing Session →"** dialog walks you through a 3-step process:
 2. Open the browser console (F12 → Console) and run the one-line script shown in the dialog.
 3. Copy the output (a small JSON blob) and paste it into the dialog.
 
+Once connected, TokenPulse silently refreshes the CSRF token when it rotates (the common
+auth failure) by re-fetching the SPA landing page, so a still-valid session keeps working
+without reconnecting.
+
 ### Why does OpenRouter require a Provisioning Key specifically?
 
 OpenRouter's regular API keys do **not** expose the `/api/v1/credits` endpoint. Only

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/ProviderRegistry.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/ProviderRegistry.kt
@@ -6,6 +6,7 @@ import org.zhavoronkov.tokenpulse.model.ConnectionType
 import org.zhavoronkov.tokenpulse.provider.anthropic.claudecode.ClaudeCodeProviderClient
 import org.zhavoronkov.tokenpulse.provider.cline.ClineProviderClient
 import org.zhavoronkov.tokenpulse.provider.nebius.NebiusProviderClient
+import org.zhavoronkov.tokenpulse.provider.nebius.NebiusSessionRefresher
 import org.zhavoronkov.tokenpulse.provider.openai.chatgpt.CodexProviderClient
 import org.zhavoronkov.tokenpulse.provider.openai.platform.OpenAiPlatformProviderClient
 import org.zhavoronkov.tokenpulse.provider.openrouter.OpenRouterPluginBridgeClient
@@ -47,7 +48,14 @@ class DefaultProviderRegistry(
     private val openRouterClient by lazy { OpenRouterProviderClient(httpClient, gson) }
     private val openRouterPluginClient by lazy { OpenRouterPluginBridgeClient() }
     private val clineClient by lazy { ClineProviderClient(httpClient, gson) }
-    private val nebiusClient by lazy { NebiusProviderClient(httpClient, gson) }
+    private val nebiusClient by lazy {
+        NebiusProviderClient(
+            httpClient = httpClient,
+            gson = gson,
+            csrfRefresher = NebiusSessionRefresher(httpClient),
+            sessionWriter = sessionWriter
+        )
+    }
     private val openAiPlatformClient by lazy { OpenAiPlatformProviderClient(httpClient, gson) }
     private val codexClient by lazy { CodexProviderClient() }
     private val claudeCodeClient by lazy { ClaudeCodeProviderClient() }

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/nebius/NebiusProviderClient.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/nebius/NebiusProviderClient.kt
@@ -56,7 +56,9 @@ import java.time.Instant
 class NebiusProviderClient(
     httpClient: OkHttpClient = OkHttpClient(),
     private val gson: Gson = Gson(),
-    private val baseUrl: String = NEBIUS_BASE_URL
+    private val baseUrl: String = NEBIUS_BASE_URL,
+    private val csrfRefresher: NebiusSessionRefresher = NebiusSessionRefresher(httpClient, baseUrl),
+    private val sessionWriter: (accountId: String, newSecretJson: String) -> Unit = { _, _ -> }
 ) : ProviderClient {
 
     internal var commandExecutor: CommandExecutor = DefaultCommandExecutor
@@ -100,7 +102,63 @@ class NebiusProviderClient(
         val testMode = System.getProperty("tokenpulse.testMode", "false").toBoolean()
         val tenantName: String? = if (!testMode) fetchTenantName(session, account, traceId) else null
 
-        val paidResult = fetchPaidBalance(session, account, traceId)
+        val authSignal = java.util.concurrent.atomic.AtomicBoolean(false)
+        val firstPass = runBalancePass(session, account, tenantName, traceId, authSignal)
+
+        // Shared, one-shot silent CSRF refresh: the most common Nebius auth
+        // failure is a rotated csrfToken against a still-valid session cookie.
+        // Trigger when the pass surfaced an AuthError directly, OR when a
+        // strategy observed an auth failure that the fallback cascade masked
+        // into a NetworkError. Re-mint the token once via the landing page,
+        // persist it, and retry the whole pass with it.
+        val sawAuthFailure = firstPass is ProviderResult.Failure.AuthError || authSignal.get()
+        if (firstPass is ProviderResult.Failure && sawAuthFailure) {
+            val refreshed = csrfRefresher.refreshCsrf(session)
+            if (refreshed != null) {
+                sessionWriter(account.id, gson.toJson(refreshed))
+                TokenPulseLogger.trace(
+                    "NEBIUS",
+                    account.id,
+                    traceId,
+                    "csrf_refreshed",
+                    "CSRF token refreshed; retrying balance fetch"
+                )
+                val tenantAfter = if (!testMode) fetchTenantName(refreshed, account, traceId) else null
+                return runBalancePass(refreshed, account, tenantAfter, traceId)
+            }
+        }
+
+        return firstPass
+    }
+
+    /**
+     * One paid+trial fetch pass with a given [session]. A hard paid failure
+     * (AuthError / RateLimited) short-circuits and is returned directly so the
+     * caller can decide whether to attempt a silent refresh.
+     */
+    private fun runBalancePass(
+        session: NebiusSession,
+        account: Account,
+        tenantName: String?,
+        traceId: String
+    ): ProviderResult = runBalancePass(session, account, tenantName, traceId, authSignal = null)
+
+    /**
+     * [authSignal], when provided, is set to true if any endpoint strategy
+     * produced an [ProviderResult.Failure.AuthError] during this pass — even if
+     * the pass ultimately degraded to a [ProviderResult.Failure.NetworkError]
+     * (which happens because [tryStrategy] masks non-Success results while it
+     * falls through the strategy cascade). The caller uses it to decide whether
+     * a silent CSRF refresh is worth attempting.
+     */
+    private fun runBalancePass(
+        session: NebiusSession,
+        account: Account,
+        tenantName: String?,
+        traceId: String,
+        authSignal: java.util.concurrent.atomic.AtomicBoolean?
+    ): ProviderResult {
+        val paidResult = fetchPaidBalance(session, account, traceId, authSignal)
         val paidSuccess = paidResult as? ProviderResult.Success
         val paidHardFailure = paidResult is ProviderResult.Failure.AuthError ||
             paidResult is ProviderResult.Failure.RateLimited
@@ -109,7 +167,7 @@ class NebiusProviderClient(
             return paidResult
         }
 
-        val trialResult = fetchTrialBalance(session, account, traceId)
+        val trialResult = fetchTrialBalance(session, account, traceId, authSignal)
         val trialSuccess = trialResult as? ProviderResult.Success
 
         return combineResults(account, paidSuccess, trialSuccess, tenantName, traceId)
@@ -208,7 +266,12 @@ class NebiusProviderClient(
         }
     }
 
-    private fun fetchPaidBalance(session: NebiusSession, account: Account, traceId: String): ProviderResult {
+    private fun fetchPaidBalance(
+        session: NebiusSession,
+        account: Account,
+        traceId: String,
+        authSignal: java.util.concurrent.atomic.AtomicBoolean? = null
+    ): ProviderResult {
         val contractId = session.parentId ?: return ProviderResult.Failure.AuthError(
             "Missing contractId in Nebius session. Please reconnect via Settings → Accounts → Edit."
         )
@@ -218,11 +281,17 @@ class NebiusProviderClient(
             traceId,
             BALANCE_ENDPOINT,
             contractId,
-            ::parsePaidBalanceResponse
+            ::parsePaidBalanceResponse,
+            authSignal
         )
     }
 
-    private fun fetchTrialBalance(session: NebiusSession, account: Account, traceId: String): ProviderResult {
+    private fun fetchTrialBalance(
+        session: NebiusSession,
+        account: Account,
+        traceId: String,
+        authSignal: java.util.concurrent.atomic.AtomicBoolean? = null
+    ): ProviderResult {
         if (!validateSession(session)) {
             return ProviderResult.Failure.AuthError(
                 "Nebius session is incomplete. Please reconnect via Settings → Accounts → Edit."
@@ -234,7 +303,8 @@ class NebiusProviderClient(
             traceId,
             TRIAL_ENDPOINT,
             session.parentId ?: "",
-            ::parseTrialResponse
+            ::parseTrialResponse,
+            authSignal
         )
     }
 
@@ -244,20 +314,21 @@ class NebiusProviderClient(
         traceId: String,
         endpoint: String,
         contractId: String,
-        parser: (Account, String) -> ProviderResult
+        parser: (Account, String) -> ProviderResult,
+        authSignal: java.util.concurrent.atomic.AtomicBoolean? = null
     ): ProviderResult {
         val hasParityData = !session.rawCookieHeader.isNullOrBlank()
         val errors = mutableListOf<String>()
         var result: ProviderResult? = null
 
         if (hasParityData) {
-            result = tryStrategy("NativeCurl", account, traceId) {
+            result = tryStrategy("NativeCurl", account, traceId, authSignal) {
                 executeWithNativeCurl(session, endpoint, contractId, parser, account)
             }
             if (result == null) errors.add("NativeCurl: failed")
 
             if (result == null) {
-                result = tryStrategy("Parity+Standard", account, traceId) {
+                result = tryStrategy("Parity+Standard", account, traceId, authSignal) {
                     val request = buildRequest(session, endpoint, contractId, useParity = true)
                     executeWithClient(baseClient, request, account, parser)
                 }
@@ -265,7 +336,7 @@ class NebiusProviderClient(
             }
 
             if (result == null) {
-                result = tryStrategy("Parity+HTTP/1.1", account, traceId) {
+                result = tryStrategy("Parity+HTTP/1.1", account, traceId, authSignal) {
                     val request = buildRequest(session, endpoint, contractId, useParity = true)
                     executeWithClient(http1Client, request, account, parser)
                 }
@@ -274,7 +345,7 @@ class NebiusProviderClient(
         }
 
         if (result == null) {
-            result = tryStrategy("Constructed+Standard", account, traceId) {
+            result = tryStrategy("Constructed+Standard", account, traceId, authSignal) {
                 val request = buildRequest(session, endpoint, contractId, useParity = false)
                 executeWithClient(baseClient, request, account, parser)
             }
@@ -282,7 +353,7 @@ class NebiusProviderClient(
         }
 
         if (result == null) {
-            result = tryStrategy("Direct", account, traceId) {
+            result = tryStrategy("Direct", account, traceId, authSignal) {
                 val request = buildRequest(session, endpoint, contractId, useParity = hasParityData)
                 executeWithClient(directClient, request, account, parser)
             }
@@ -297,10 +368,12 @@ class NebiusProviderClient(
         name: String,
         account: Account,
         traceId: String,
+        authSignal: java.util.concurrent.atomic.AtomicBoolean?,
         block: () -> ProviderResult
     ): ProviderResult? {
         return try {
             val result = block()
+            if (result is ProviderResult.Failure.AuthError) authSignal?.set(true)
             result as? ProviderResult.Success
         } catch (e: Exception) {
             TokenPulseLogger.trace(

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/nebius/NebiusSessionRefresher.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/nebius/NebiusSessionRefresher.kt
@@ -1,0 +1,124 @@
+package org.zhavoronkov.tokenpulse.provider.nebius
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.zhavoronkov.tokenpulse.utils.TokenPulseLogger
+
+/**
+ * Cheap, always-safe CSRF-only refresh for a Nebius Token Factory session.
+ *
+ * ## Why this exists
+ * The stored Nebius session carries two moving parts: the `__Host-app_session`
+ * cookie (the actual login) and the `csrfToken` (`x-csrf-token` header + the
+ * `__Host-psifi.x-csrf-token` cookie). The `csrfToken` rotates far more often
+ * than the session cookie expires, so the single most common auth failure is a
+ * stale token against a still-valid session — surfaced by the billing gateway
+ * as an `EBADCSRFTOKEN` / 401 / 403 envelope.
+ *
+ * This refresher fixes exactly that case with a plain HTTP call (no browser): it
+ * re-fetches the SPA landing page (`GET /`) with the current cookies and scrapes
+ * the fresh `csrfToken` that the page embeds in `window.__DATA__`. If the page
+ * also rotates the CSRF cookie via `Set-Cookie`, we adopt that too.
+ *
+ * ## Flow
+ * 1. `GET {baseUrl}/` with the current cookies, WITHOUT following redirects.
+ * 2. If the response is a 3xx (bounced to `/auth/redirect` → OAuth), the session
+ *    cookie itself is dead — return `null` so the caller surfaces a reconnect
+ *    prompt (the user must re-capture the session).
+ * 3. If 200, read a bounded prefix of the HTML and require
+ *    `"isAuthenticatedOnPageLoad":true`; otherwise the session is dead → `null`.
+ * 4. Extract `"csrfToken":"<hex>"` from `window.__DATA__`. Return a copy of the
+ *    session with the fresh token (and rotated CSRF cookie, if any).
+ *
+ * Returns `null` whenever the silent CSRF refresh cannot complete; the caller
+ * then decides whether to attempt a heavier recovery or surface an AuthError.
+ */
+class NebiusSessionRefresher(
+    private val httpClient: OkHttpClient,
+    private val baseUrl: String = NEBIUS_BASE_URL
+) {
+
+    /**
+     * Attempt a CSRF-only refresh. Requires a non-blank `appSession`; returns
+     * `null` otherwise (nothing to authenticate the landing-page fetch with).
+     */
+    fun refreshCsrf(session: NebiusProviderClient.NebiusSession): NebiusProviderClient.NebiusSession? {
+        if (session.appSession.isNullOrBlank()) {
+            TokenPulseLogger.Provider.debug("Nebius CSRF refresh skipped: no appSession")
+            return null
+        }
+
+        // A per-refresh client that does NOT auto-follow redirects: a 3xx here
+        // means the session cookie is dead and we must not silently chase the
+        // OAuth chain (which OkHttp cannot complete anyway).
+        val stepClient = httpClient.newBuilder()
+            .followRedirects(false)
+            .followSslRedirects(false)
+            .build()
+
+        return try {
+            val request = Request.Builder()
+                .url("$baseUrl/")
+                .header("accept", "text/html,application/xhtml+xml")
+                .header("cookie", cookieHeader(session))
+                .build()
+
+            stepClient.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    TokenPulseLogger.Provider.debug("Nebius CSRF refresh: landing page not 2xx (${response.code})")
+                    return null
+                }
+                val html = response.body?.source()?.let { source ->
+                    source.request(MAX_HTML_BYTES)
+                    source.buffer.snapshot().utf8()
+                }.orEmpty()
+
+                if (!isAuthenticated(html)) {
+                    TokenPulseLogger.Provider.debug("Nebius CSRF refresh: page not authenticated")
+                    return null
+                }
+                val freshToken = extractCsrfToken(html) ?: run {
+                    TokenPulseLogger.Provider.debug("Nebius CSRF refresh: no csrfToken in landing page")
+                    return null
+                }
+                val rotatedCookie = extractRotatedCsrfCookie(response.headers("Set-Cookie"))
+                session.copy(
+                    csrfToken = freshToken,
+                    csrfCookie = rotatedCookie ?: session.csrfCookie
+                )
+            }
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            TokenPulseLogger.Provider.warn("Nebius CSRF refresh failed: ${e.message}")
+            null
+        }
+    }
+
+    private fun cookieHeader(session: NebiusProviderClient.NebiusSession): String {
+        if (!session.rawCookieHeader.isNullOrBlank()) return session.rawCookieHeader
+        return "__Host-app_session=${session.appSession}; __Host-psifi.x-csrf-token=${session.csrfCookie}"
+    }
+
+    private fun isAuthenticated(html: String): Boolean =
+        html.contains("\"isAuthenticatedOnPageLoad\":true") ||
+            html.contains("\"isAuthenticatedOnPageLoad\": true")
+
+    private fun extractCsrfToken(html: String): String? =
+        CSRF_TOKEN_REGEX.find(html)?.groupValues?.get(1)?.takeIf { it.isNotBlank() }
+
+    private fun extractRotatedCsrfCookie(setCookies: List<String>): String? {
+        val prefix = "__Host-psifi.x-csrf-token="
+        for (header in setCookies) {
+            val first = header.substringBefore(';').trim()
+            if (first.startsWith(prefix)) {
+                return first.substring(prefix.length).takeIf { it.isNotBlank() }
+            }
+        }
+        return null
+    }
+
+    companion object {
+        const val NEBIUS_BASE_URL = "https://tokenfactory.nebius.com"
+        private const val MAX_HTML_BYTES = 262_144L
+        private val CSRF_TOKEN_REGEX = Regex(""""csrfToken"\s*:\s*"([^"]+)"""")
+    }
+}

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/NebiusProviderClientTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/NebiusProviderClientTest.kt
@@ -2,10 +2,13 @@ package org.zhavoronkov.tokenpulse.provider
 
 import com.google.gson.Gson
 import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -15,9 +18,11 @@ import org.junit.jupiter.api.Test
 import org.zhavoronkov.tokenpulse.model.ConnectionType
 import org.zhavoronkov.tokenpulse.model.ProviderResult
 import org.zhavoronkov.tokenpulse.provider.nebius.NebiusProviderClient
+import org.zhavoronkov.tokenpulse.provider.nebius.NebiusSessionRefresher
 import org.zhavoronkov.tokenpulse.settings.Account
 import org.zhavoronkov.tokenpulse.settings.AuthType
 import java.math.BigDecimal
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Unit tests for NebiusProviderClient.
@@ -589,5 +594,160 @@ class NebiusProviderClientTest {
         val credits = (result as ProviderResult.Success).snapshot.balance.credits!!
         // Combined: 0.00 + 0.50 = 0.50
         assertEquals(0, credits.remaining!!.compareTo(BigDecimal("0.50")))
+    }
+
+    // ── Silent CSRF refresh on auth failure ────────────────────────────────
+
+    private fun authErrorEnvelope() = MockResponse()
+        .setResponseCode(200)
+        .setHeader("Content-Type", "application/json")
+        .setBody("""{"code":"EBADCSRFTOKEN","statusCode":403,"message":"invalid csrf token"}""")
+
+    private fun landingPageAuthenticated(token: String) = MockResponse()
+        .setResponseCode(200)
+        .setHeader("Content-Type", "text/html")
+        .setBody(
+            """<html><script>window.__DATA__ = """ +
+                """{"csrfToken":"$token","isAuthenticatedOnPageLoad":true};</script></html>"""
+        )
+
+    /**
+     * Build a client whose CSRF refresher and balance endpoints both target the
+     * mock server, capturing any persisted session via [writes].
+     */
+    private fun refreshingClient(writes: MutableList<Pair<String, String>>): NebiusProviderClient {
+        val base = server.url("").toString().trimEnd('/')
+        return NebiusProviderClient(
+            httpClient = OkHttpClient(),
+            gson = gson,
+            baseUrl = base,
+            csrfRefresher = NebiusSessionRefresher(OkHttpClient(), base),
+            sessionWriter = { id, json -> writes.add(id to json) }
+        )
+    }
+
+    @Test
+    fun `fetchBalance refreshes csrf then retries and persists new session`() {
+        val writes = mutableListOf<Pair<String, String>>()
+        val client = refreshingClient(writes)
+        val landingHits = AtomicInteger(0)
+
+        // First pass: paid+trial both return EBADCSRFTOKEN so the whole pass fails with
+        // an auth signal. Landing page returns a fresh token. Only AFTER the landing page
+        // has been hit (i.e. on the retry pass) do the endpoints succeed.
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                val path = request.path ?: ""
+                val refreshed = landingHits.get() > 0
+                return when {
+                    path == "/" -> {
+                        landingHits.incrementAndGet()
+                        landingPageAuthenticated("FRESH-TOKEN")
+                    }
+                    path.contains("/customers/getBalance") ->
+                        if (refreshed) paidBalanceResponse("5.00") else authErrorEnvelope()
+                    path.contains("/getCurrentTrial") ->
+                        if (refreshed) trialBalanceResponse("1.00", "0.25") else authErrorEnvelope()
+                    else -> MockResponse().setResponseCode(404)
+                }
+            }
+        }
+
+        val result = client.fetchBalance(testAccount, validSessionJson)
+
+        assertInstanceOf(ProviderResult.Success::class.java, result)
+        // sessionWriter persisted the refreshed session with the fresh token.
+        assertEquals(1, writes.size)
+        val persisted = gson.fromJson(writes[0].second, NebiusProviderClient.NebiusSession::class.java)
+        assertEquals("FRESH-TOKEN", persisted.csrfToken)
+        assertEquals(testAccount.id, writes[0].first)
+        assertEquals(1, landingHits.get())
+    }
+
+    @Test
+    fun `fetchBalance does not persist when csrf refresh yields no token`() {
+        val writes = mutableListOf<Pair<String, String>>()
+        val client = refreshingClient(writes)
+
+        // Every balance call is an auth error; landing page is NOT authenticated,
+        // so refresh returns null → no retry, no persist.
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                val path = request.path ?: ""
+                return when {
+                    path == "/" -> MockResponse()
+                        .setResponseCode(200)
+                        .setHeader("Content-Type", "text/html")
+                        .setBody("""<html><script>window.__DATA__={"isAuthenticatedOnPageLoad":false};</script></html>""")
+                    path.contains("/customers/getBalance") -> authErrorEnvelope()
+                    path.contains("/getCurrentTrial") -> authErrorEnvelope()
+                    else -> MockResponse().setResponseCode(404)
+                }
+            }
+        }
+
+        val result = client.fetchBalance(testAccount, validSessionJson)
+
+        assertTrue(result is ProviderResult.Failure)
+        assertTrue(writes.isEmpty(), "No session should be persisted when refresh fails")
+    }
+
+    @Test
+    fun `fetchBalance attempts csrf refresh at most once (no loop)`() {
+        val writes = mutableListOf<Pair<String, String>>()
+        val client = refreshingClient(writes)
+        val landingHits = AtomicInteger(0)
+
+        // Balance ALWAYS returns auth error; landing page always authenticates with a
+        // fresh token. If the retry looped, the landing page would be hit more than once.
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                val path = request.path ?: ""
+                return when {
+                    path == "/" -> {
+                        landingHits.incrementAndGet()
+                        landingPageAuthenticated("FRESH-TOKEN")
+                    }
+                    path.contains("/customers/getBalance") -> authErrorEnvelope()
+                    path.contains("/getCurrentTrial") -> authErrorEnvelope()
+                    else -> MockResponse().setResponseCode(404)
+                }
+            }
+        }
+
+        val result = client.fetchBalance(testAccount, validSessionJson)
+
+        assertTrue(result is ProviderResult.Failure)
+        // Exactly one refresh attempt, one persist — the retry does not refresh again.
+        assertEquals(1, landingHits.get())
+        assertEquals(1, writes.size)
+    }
+
+    @Test
+    fun `fetchBalance does not refresh when there is no auth failure`() {
+        val writes = mutableListOf<Pair<String, String>>()
+        val client = refreshingClient(writes)
+        val landingHits = AtomicInteger(0)
+
+        server.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                val path = request.path ?: ""
+                return when {
+                    path == "/" -> {
+                        landingHits.incrementAndGet()
+                        landingPageAuthenticated("SHOULD-NOT-BE-FETCHED")
+                    }
+                    path.contains("/customers/getBalance") -> paidBalanceResponse("5.00")
+                    path.contains("/getCurrentTrial") -> trialBalanceResponse("1.00", "0.25")
+                    else -> MockResponse().setResponseCode(404)
+                }
+            }
+        }
+
+        val result = client.fetchBalance(testAccount, validSessionJson)
+
+        assertInstanceOf(ProviderResult.Success::class.java, result)
+        assertEquals(0, landingHits.get(), "Landing page must not be fetched on success")
+        assertFalse(writes.isNotEmpty(), "No refresh persist on success")
     }
 }

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/nebius/NebiusSessionRefresherTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/nebius/NebiusSessionRefresherTest.kt
@@ -1,0 +1,145 @@
+package org.zhavoronkov.tokenpulse.provider.nebius
+
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class NebiusSessionRefresherTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var refresher: NebiusSessionRefresher
+
+    private fun session() = NebiusProviderClient.NebiusSession(
+        appSession = "app-session-abc",
+        csrfCookie = "old-csrf-cookie",
+        csrfToken = "old-csrf-token",
+        parentId = "contract-1"
+    )
+
+    private fun authenticatedHtml(token: String) =
+        """<!doctype html><html><head><script>window.__DATA__ = """ +
+            """{"config":{"appEnvironment":"prod"},"csrfToken":"$token",""" +
+            """"isAuthenticatedOnPageLoad":true,"mfes":{}};</script></head><body></body></html>"""
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        refresher = NebiusSessionRefresher(
+            httpClient = OkHttpClient(),
+            baseUrl = server.url("/").toString().removeSuffix("/")
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `refreshCsrf returns fresh token from authenticated landing page`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "text/html")
+                .setBody(authenticatedHtml("NEW-CSRF-TOKEN"))
+        )
+
+        val result = refresher.refreshCsrf(session())
+
+        requireNotNull(result)
+        assertEquals("NEW-CSRF-TOKEN", result.csrfToken)
+        // No Set-Cookie => the CSRF cookie is preserved.
+        assertEquals("old-csrf-cookie", result.csrfCookie)
+        // Session identity preserved.
+        assertEquals("app-session-abc", result.appSession)
+        assertEquals("contract-1", result.parentId)
+    }
+
+    @Test
+    fun `refreshCsrf adopts rotated csrf cookie from Set-Cookie`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "text/html")
+                .addHeader("Set-Cookie", "__Host-psifi.x-csrf-token=ROTATED-COOKIE; Path=/; HttpOnly")
+                .setBody(authenticatedHtml("NEW-CSRF-TOKEN"))
+        )
+
+        val result = refresher.refreshCsrf(session())
+
+        requireNotNull(result)
+        assertEquals("NEW-CSRF-TOKEN", result.csrfToken)
+        assertEquals("ROTATED-COOKIE", result.csrfCookie)
+    }
+
+    @Test
+    fun `refreshCsrf returns null when page is not authenticated`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "text/html")
+                .setBody(
+                    """<html><script>window.__DATA__ = """ +
+                        """{"csrfToken":"x","isAuthenticatedOnPageLoad":false};</script></html>"""
+                )
+        )
+
+        assertNull(refresher.refreshCsrf(session()))
+    }
+
+    @Test
+    fun `refreshCsrf returns null on redirect (session cookie dead)`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(302)
+                .setHeader("Location", "/auth/redirect?redirect_uri=%2F")
+        )
+
+        assertNull(refresher.refreshCsrf(session()))
+    }
+
+    @Test
+    fun `refreshCsrf returns null when csrfToken is absent`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "text/html")
+                .setBody("""<html><script>window.__DATA__ = {"isAuthenticatedOnPageLoad":true};</script></html>""")
+        )
+
+        assertNull(refresher.refreshCsrf(session()))
+    }
+
+    @Test
+    fun `refreshCsrf skips network when appSession is blank`() {
+        val result = refresher.refreshCsrf(
+            NebiusProviderClient.NebiusSession(appSession = null, csrfCookie = "c", csrfToken = "t", parentId = "p")
+        )
+        assertNull(result)
+        assertEquals(0, server.requestCount)
+    }
+
+    @Test
+    fun `refreshCsrf sends current cookies to landing page`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "text/html")
+                .setBody(authenticatedHtml("T"))
+        )
+
+        refresher.refreshCsrf(session())
+
+        val recorded = server.takeRequest()
+        assertEquals("GET", recorded.method)
+        val cookie = recorded.getHeader("cookie") ?: ""
+        assertEquals(true, cookie.contains("__Host-app_session=app-session-abc"))
+        assertEquals(true, cookie.contains("__Host-psifi.x-csrf-token=old-csrf-cookie"))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `NebiusSessionRefresher` — a headless (pure OkHttp, no browser) refresh for the most common Nebius auth failure: a rotated `csrfToken` against a still-valid session cookie (`EBADCSRFTOKEN` / 401 / 403).
- Wires a one-shot silent refresh + retry into `NebiusProviderClient`, persisting the refreshed session via `sessionWriter`. Connecting remains manual cURL capture only.

## How it works
- `NebiusSessionRefresher.refreshCsrf` re-fetches the SPA landing page (`GET /`, no redirect following), requires `"isAuthenticatedOnPageLoad":true`, scrapes the fresh `csrfToken` from `window.__DATA__`, and adopts a rotated `__Host-psifi.x-csrf-token` cookie if the page sets one.
- Returns `null` on redirect (session cookie dead) or unauth, so the caller surfaces the existing reconnect prompt.
- In `NebiusProviderClient`, the refresh fires only when a fetch pass fails **and** an auth signal was observed. The signal is an `AtomicBoolean` threaded through `tryStrategy`, so it triggers even when the strategy fallback cascade masks the `AuthError` into a `NetworkError`. On success the pass is retried exactly once (no loop).

## Tests
- `NebiusSessionRefresherTest` (7): fresh token, rotated-cookie adoption, unauth→null, redirect→null, missing-token→null, blank-appSession skip, cookie-header assertion.
- `NebiusProviderClientTest` (+4): refresh→retry→persist, refresh-yields-no-token→no-persist, at-most-once/no-loop, no-refresh-on-success.
- Full gate green: `./gradlew test detekt` → 731 tests, 0 failures; detekt SARIF 0 findings.

## Notes
- An earlier JCEF-based sign-in / hidden re-mint approach was dropped because Google (and other IdPs) refuse OAuth inside embedded webviews. This PR keeps only the browser-free CSRF refresh.