### PR TITLE
Unify tooltip progress bars on a single remaining% convention

### DIFF
--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/ProgressBarRenderer.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/ProgressBarRenderer.kt
@@ -4,7 +4,8 @@ import com.intellij.ui.JBColor
 import java.awt.Color
 
 /**
- * Provides theme-aware color selection for usage and balance percentages.
+ * Provides theme-aware color selection for the remaining% shown by every
+ * usage bar.
  *
  * The bars themselves are drawn as real Swing components by
  * [TokenPulseTooltipPanel]; this object only decides the fill color for a
@@ -12,40 +13,29 @@ import java.awt.Color
  */
 object ProgressBarRenderer {
 
-    /** Threshold percentage for red (critical) color. */
-    private const val CRITICAL_THRESHOLD = 90
+    /** Remaining% at or below this is red (critical). */
+    private const val CRITICAL_THRESHOLD = 10
 
-    /** Threshold percentage for orange (warning) color. */
-    private const val WARNING_THRESHOLD = 70
+    /** Remaining% at or below this is orange (warning). */
+    private const val WARNING_THRESHOLD = 30
 
-    /** Red color for critical usage (>= 90%) — theme-aware. */
+    /** Red color for critical remaining (<= 10%) — theme-aware. */
     private val COLOR_CRITICAL = JBColor(Color(0xCC4444), Color(0xFF7777))
 
-    /** Orange color for warning usage (>= 70%) — theme-aware. */
+    /** Orange color for warning remaining (<= 30%) — theme-aware. */
     private val COLOR_WARNING = JBColor(Color(0xCC8800), Color(0xFFBB55))
 
-    /** Green color for normal usage (< 70%) — theme-aware. */
+    /** Green color for healthy remaining (> 30%) — theme-aware. */
     private val COLOR_NORMAL = JBColor(Color(0x44AA44), Color(0x66DD66))
 
     /**
-     * Get color for usage percentage.
+     * Get color for a remaining percentage: high remaining = green, low
+     * remaining = red.
      */
     fun getUsageColor(percent: Int): Color {
         return when {
-            percent >= CRITICAL_THRESHOLD -> COLOR_CRITICAL
-            percent >= WARNING_THRESHOLD -> COLOR_WARNING
-            else -> COLOR_NORMAL
-        }
-    }
-
-    /**
-     * Get color for balance percentage (inverted from usage).
-     * High remaining = green, low remaining = red.
-     */
-    fun getBalanceColor(remainingPercent: Int): Color {
-        return when {
-            remainingPercent <= 10 -> COLOR_CRITICAL
-            remainingPercent <= 30 -> COLOR_WARNING
+            percent <= CRITICAL_THRESHOLD -> COLOR_CRITICAL
+            percent <= WARNING_THRESHOLD -> COLOR_WARNING
             else -> COLOR_NORMAL
         }
     }

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/TokenPulseTooltipPanel.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/TokenPulseTooltipPanel.kt
@@ -263,17 +263,6 @@ object TokenPulseTooltipPanel {
                     resetInline = row.resetInline,
                 ),
             )
-            is TooltipRow.BalanceBar -> addBarRow(
-                panel,
-                gbc,
-                BarRowContent(
-                    label = row.label,
-                    fillPercent = row.remainingPercent,
-                    labelText = "${row.remainingPercent.coerceIn(0, 100)}%",
-                    color = ProgressBarRenderer.getBalanceColor(row.remainingPercent),
-                    resetInline = row.resetInline,
-                ),
-            )
             is TooltipRow.Info -> panel.add(
                 JBLabel(row.message).apply {
                     font = JBFont.medium()

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/TooltipModel.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/TooltipModel.kt
@@ -25,16 +25,11 @@ internal object TooltipModel {
     internal sealed interface TooltipRow {
         data class LabelValue(val label: String, val value: String, val bold: Boolean = false) : TooltipRow
 
-        // UsageBar: fillPercent (0..100) is CONSUMED and drives the bar fill +
-        // color (high = red); labelText is the pre-formatted right-column text
-        // (Claude/Codex show remaining e.g. "98%", Cline shows used e.g. "50%").
+        // UsageBar: fillPercent (0..100) is REMAINING and drives the bar fill +
+        // color (high = green, low = red); labelText is the pre-formatted
+        // right-column text, consistently showing the same remaining% value.
         data class UsageBar(val label: String, val fillPercent: Int, val labelText: String, val resetInline: String?) :
             TooltipRow
-        data class BalanceBar(
-            val label: String,
-            val remainingPercent: Int,
-            val resetInline: String? = null
-        ) : TooltipRow
         data class Info(val message: String) : TooltipRow
         data class Error(val message: String, val warning: Boolean = false) : TooltipRow
         data class SectionHeader(val title: String) : TooltipRow
@@ -155,9 +150,8 @@ internal object TooltipModel {
 
     /**
      * Append a Codex usage-bar row when [used] is a parseable non-`N/A` value.
-     * [used] is a "percent used" number; the bar fills with CONSUMED (used%)
-     * and the printed label reads REMAINING (100 - used%). Delegates to
-     * [claudeUsageBar] to share the Claude/Codex "remaining-label" convention.
+     * [used] is a "percent used" number; delegates to [claudeUsageBar] to
+     * convert it to the shared remaining% bar/label convention.
      */
     private fun addCodexBar(
         rows: MutableList<TooltipRow>,
@@ -226,10 +220,10 @@ internal object TooltipModel {
         metadata["status"]?.let { rows.add(TooltipRow.Info("Status: $it")) }
     }
 
-    /** Claude / Codex convention: bar fills with CONSUMED (used%), label reads REMAINING. */
+    /** [used] is percent used; the bar fills and labels with the remaining%. */
     private fun claudeUsageBar(label: String, used: Int, resetsAtIso: String?): TooltipRow.UsageBar {
-        val used0 = used.coerceIn(0, 100)
-        return TooltipRow.UsageBar(label, used0, "${100 - used0}%", resetInline(resetsAtIso))
+        val remaining0 = (100 - used.coerceIn(0, 100)).coerceIn(0, 100)
+        return TooltipRow.UsageBar(label, remaining0, "$remaining0%", resetInline(resetsAtIso))
     }
 
     /**
@@ -270,7 +264,8 @@ internal object TooltipModel {
 
         // Token Plan usage block.
         metadata?.get("sessionUsed")?.toIntOrNull()?.let {
-            rows.add(TooltipRow.BalanceBar("Credits", 100 - it))
+            val remaining0 = (100 - it).coerceIn(0, 100)
+            rows.add(TooltipRow.UsageBar("Credits", remaining0, "$remaining0%", null))
         }
         val planUsed = tokens?.used
         val planTotal = tokens?.total
@@ -313,10 +308,8 @@ internal object TooltipModel {
         if (metrics.isEmpty()) return
         rows.add(TooltipRow.SectionHeader(ClinePassUsageRenderer.SECTION_TITLE))
         for (metric in metrics) {
-            // Cline convention: bar fill AND label both read USED% (unchanged
-            // wording); reset time renders inline in col 3.
-            val used0 = metric.percent.coerceIn(0, 100)
-            rows.add(TooltipRow.UsageBar(metric.label, used0, "$used0%", resetInline(metric.resetAt)))
+            val remaining0 = (100 - metric.percent.coerceIn(0, 100)).coerceIn(0, 100)
+            rows.add(TooltipRow.UsageBar(metric.label, remaining0, "$remaining0%", resetInline(metric.resetAt)))
         }
     }
 

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/ui/ProgressBarRendererTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/ui/ProgressBarRendererTest.kt
@@ -11,74 +11,38 @@ import java.awt.Color
 class ProgressBarRendererTest {
 
     @Test
-    fun `getUsageColor returns green for low usage`() {
-        val green = ProgressBarRenderer.getUsageColor(0)
+    fun `getUsageColor returns green for high remaining`() {
+        val green = ProgressBarRenderer.getUsageColor(100)
         assertEquals(JBColor(Color(0x44AA44), Color(0x66DD66)), green)
 
         val green50 = ProgressBarRenderer.getUsageColor(50)
         assertEquals(JBColor(Color(0x44AA44), Color(0x66DD66)), green50)
 
-        val green69 = ProgressBarRenderer.getUsageColor(69)
-        assertEquals(JBColor(Color(0x44AA44), Color(0x66DD66)), green69)
-    }
-
-    @Test
-    fun `getUsageColor returns orange for medium usage`() {
-        val orange70 = ProgressBarRenderer.getUsageColor(70)
-        assertEquals(JBColor(Color(0xCC8800), Color(0xFFBB55)), orange70)
-
-        val orange80 = ProgressBarRenderer.getUsageColor(80)
-        assertEquals(JBColor(Color(0xCC8800), Color(0xFFBB55)), orange80)
-
-        val orange89 = ProgressBarRenderer.getUsageColor(89)
-        assertEquals(JBColor(Color(0xCC8800), Color(0xFFBB55)), orange89)
-    }
-
-    @Test
-    fun `getUsageColor returns red for high usage`() {
-        val red90 = ProgressBarRenderer.getUsageColor(90)
-        assertEquals(JBColor(Color(0xCC4444), Color(0xFF7777)), red90)
-
-        val red95 = ProgressBarRenderer.getUsageColor(95)
-        assertEquals(JBColor(Color(0xCC4444), Color(0xFF7777)), red95)
-
-        val red100 = ProgressBarRenderer.getUsageColor(100)
-        assertEquals(JBColor(Color(0xCC4444), Color(0xFF7777)), red100)
-    }
-
-    @Test
-    fun `getBalanceColor returns green for high remaining`() {
-        val green = ProgressBarRenderer.getBalanceColor(100)
-        assertEquals(JBColor(Color(0x44AA44), Color(0x66DD66)), green)
-
-        val green50 = ProgressBarRenderer.getBalanceColor(50)
-        assertEquals(JBColor(Color(0x44AA44), Color(0x66DD66)), green50)
-
-        val green31 = ProgressBarRenderer.getBalanceColor(31)
+        val green31 = ProgressBarRenderer.getUsageColor(31)
         assertEquals(JBColor(Color(0x44AA44), Color(0x66DD66)), green31)
     }
 
     @Test
-    fun `getBalanceColor returns orange for low remaining`() {
-        val orange30 = ProgressBarRenderer.getBalanceColor(30)
+    fun `getUsageColor returns orange for low remaining`() {
+        val orange30 = ProgressBarRenderer.getUsageColor(30)
         assertEquals(JBColor(Color(0xCC8800), Color(0xFFBB55)), orange30)
 
-        val orange20 = ProgressBarRenderer.getBalanceColor(20)
+        val orange20 = ProgressBarRenderer.getUsageColor(20)
         assertEquals(JBColor(Color(0xCC8800), Color(0xFFBB55)), orange20)
 
-        val orange11 = ProgressBarRenderer.getBalanceColor(11)
+        val orange11 = ProgressBarRenderer.getUsageColor(11)
         assertEquals(JBColor(Color(0xCC8800), Color(0xFFBB55)), orange11)
     }
 
     @Test
-    fun `getBalanceColor returns red for critical remaining`() {
-        val red10 = ProgressBarRenderer.getBalanceColor(10)
+    fun `getUsageColor returns red for critical remaining`() {
+        val red10 = ProgressBarRenderer.getUsageColor(10)
         assertEquals(JBColor(Color(0xCC4444), Color(0xFF7777)), red10)
 
-        val red5 = ProgressBarRenderer.getBalanceColor(5)
+        val red5 = ProgressBarRenderer.getUsageColor(5)
         assertEquals(JBColor(Color(0xCC4444), Color(0xFF7777)), red5)
 
-        val red0 = ProgressBarRenderer.getBalanceColor(0)
+        val red0 = ProgressBarRenderer.getUsageColor(0)
         assertEquals(JBColor(Color(0xCC4444), Color(0xFF7777)), red0)
     }
 }

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/ui/TooltipModelTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/ui/TooltipModelTest.kt
@@ -163,8 +163,8 @@ class TooltipModelTest {
         )
         val bars = rows(ConnectionType.CODEX_CLI, r).filterIsInstance<TooltipRow.UsageBar>()
         assertEquals(listOf("5-hour", "Weekly", "Code Review"), bars.map { it.label })
-        // Bar fills with CONSUMED (used %); the printed label reads REMAINING.
-        assertEquals(listOf(10, 20, 30), bars.map { it.fillPercent })
+        // Bar fills with REMAINING (100 - used %); the printed label matches.
+        assertEquals(listOf(90, 80, 70), bars.map { it.fillPercent })
         assertEquals(listOf("90%", "80%", "70%"), bars.map { it.labelText })
         // valid ISO reset -> inline present with prefix; absent -> null
         assertTrue(bars.first { it.label == "5-hour" }.resetInline!!.startsWith("Resets "))
@@ -248,8 +248,8 @@ class TooltipModelTest {
         )
         val bars = rows(ConnectionType.CLAUDE_CODE, r).filterIsInstance<TooltipRow.UsageBar>()
         assertEquals(listOf("5-hour", "7-day"), bars.map { it.label })
-        // Bar fills with CONSUMED (used %); the printed label reads REMAINING.
-        assertEquals(listOf(40, 10), bars.map { it.fillPercent })
+        // Bar fills with REMAINING (100 - used %); the printed label matches.
+        assertEquals(listOf(60, 90), bars.map { it.fillPercent })
         assertEquals(listOf("60%", "90%"), bars.map { it.labelText })
         // valid ISO -> inline reset present with prefix
         val fiveHour = bars.first { it.label == "5-hour" }
@@ -266,7 +266,7 @@ class TooltipModelTest {
         )
         val bars = rows(ConnectionType.CLAUDE_CODE, r).filterIsInstance<TooltipRow.UsageBar>()
         assertEquals(listOf("5-hour", "Weekly"), bars.map { it.label })
-        assertEquals(listOf(30, 15), bars.map { it.fillPercent })
+        assertEquals(listOf(70, 85), bars.map { it.fillPercent })
         assertEquals(listOf("70%", "85%"), bars.map { it.labelText })
     }
 
@@ -295,7 +295,7 @@ class TooltipModelTest {
             metadata = mapOf("sessionUsed" to "40"),
         )
         val out = rows(ConnectionType.XIAOMI, r)
-        assertEquals(TooltipRow.BalanceBar("Credits", 60), out[0])
+        assertEquals(TooltipRow.UsageBar("Credits", 60, "60%", null), out[0])
         assertTrue(out.any { it is TooltipRow.LabelValue && it.label == "Used:" })
     }
 
@@ -309,7 +309,7 @@ class TooltipModelTest {
         )
         val out = rows(ConnectionType.XIAOMI, r)
         assertEquals(TooltipRow.LabelValue("Balance:", "$55.48", bold = true), out[0])
-        assertTrue(out.any { it is TooltipRow.BalanceBar && it.label == "Credits" })
+        assertTrue(out.any { it is TooltipRow.UsageBar && it.label == "Credits" })
         assertTrue(out.any { it is TooltipRow.LabelValue && it.label == "Used:" })
     }
 
@@ -337,7 +337,8 @@ class TooltipModelTest {
         val bars = out.filterIsInstance<TooltipRow.UsageBar>()
         assertEquals(1, bars.size)
         assertEquals("5-hour", bars[0].label)
-        // Cline convention: bar fill AND label both read USED (unchanged).
+        // Bar fill and label both read REMAINING (100 - used %); 50 used ->
+        // 50 remaining is a coincidental fixed point of this test's input.
         assertEquals(50, bars[0].fillPercent)
         assertEquals("50%", bars[0].labelText)
         assertTrue(bars[0].resetInline!!.startsWith("Resets "))


### PR DESCRIPTION
## Summary
- Every provider row in the status-bar popup (Claude, Codex, Cline, Xiaomi) now fills and labels its progress bar with the same convention: **percent remaining**. Previously Claude/Codex filled the bar with used% but labeled it remaining%, Cline used used% for both, and Xiaomi used remaining% for both — three inconsistent behaviors.
- Collapsed `TooltipRow.BalanceBar` into `TooltipRow.UsageBar` (there was already only one Swing bar widget; the duplication was in the row model, not the renderer) and removed the now-redundant `ProgressBarRenderer.getBalanceColor`, leaving a single `getUsageColor` with remaining-based thresholds (red ≤10%, orange ≤30%, green otherwise).

## Test plan
- [x] `./gradlew test` — full suite passes, including updated `TooltipModelTest` and `ProgressBarRendererTest` assertions for the new remaining% values/colors.
- [x] Manually verify the popup in a running IDE: bars for Claude/Codex/Cline/Xiaomi all fill and label consistently as "% remaining".