### PR TITLE
Fix <html> rejected by UI DSL comment(), and platformTest running zero tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,10 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    // Bridges JUnit 3/4-style tests (e.g. IntelliJ's BasePlatformTestCase,
+    // which extends junit.framework.TestCase) onto the JUnit Platform so
+    // `platformTest` actually discovers and runs TokenPulseSmokeTest.
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.11.4")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
     // pty4j is provided by IntelliJ platform at runtime - no explicit dependency needed
@@ -145,9 +149,15 @@ tasks {
             if (!project.hasProperty("functional")) {
                 excludeTags("functional")
             }
-            // Skip the IntelliJ Platform smoke test here — it needs a serial,
-            // shared TestApplication fixture and runs in the `platformTest` task.
-            excludeTags("platform")
+        }
+        // TokenPulseSmokeTest extends IntelliJ's BasePlatformTestCase — a
+        // JUnit 3-style junit.framework.TestCase, run through the Vintage
+        // engine, which does NOT honor Jupiter's @Tag (that's Jupiter-only;
+        // Vintage only understands JUnit4 @Category). So the platform split
+        // is done by class name instead of by tag; it needs a serial, shared
+        // TestApplication fixture and runs in the `platformTest` task instead.
+        filter {
+            excludeTestsMatching("org.zhavoronkov.tokenpulse.TokenPulseSmokeTest")
         }
         systemProperty("tokenpulse.testMode", "true")
 
@@ -169,11 +179,30 @@ tasks {
         description = "Runs IntelliJ Platform tests that need the shared TestApplication."
         group = "verification"
 
-        testClassesDirs = sourceSets.test.get().output.classesDirs
-        classpath = sourceSets.test.get().runtimeClasspath
+        // The IntelliJ Platform Gradle plugin only wires its sandbox/module
+        // JVM args (IntelliJPlatformArgumentProvider, SandboxArgumentProvider,
+        // the rearranged plugin/IDE classpath, a custom javaLauncher) onto the
+        // task literally named "test". A separately `register<Test>(...)`
+        // task does NOT get that configuration automatically — without it,
+        // BasePlatformTestCase fails to bootstrap the IDE test application
+        // (IllegalAccessError in UITestUtil). So reuse the already fully
+        // configured "test" task's classpath/args/launcher here and just
+        // retarget which tests run via `filter`.
+        val testTask = named<Test>("test").get()
+        // The reused jvmArgumentProviders/classpath resolve sandbox output
+        // (prepareTestSandbox) at execution time without Gradle seeing it as
+        // a task input, so the sandbox-prep dependency must be declared
+        // explicitly here too.
+        dependsOn("prepareTestSandbox")
+        testClassesDirs = testTask.testClassesDirs
+        classpath = testTask.classpath
+        jvmArgumentProviders.addAll(testTask.jvmArgumentProviders)
+        systemProperties = testTask.systemProperties
+        javaLauncher.set(testTask.javaLauncher)
 
-        useJUnitPlatform {
-            includeTags("platform")
+        useJUnitPlatform()
+        filter {
+            includeTestsMatching("org.zhavoronkov.tokenpulse.TokenPulseSmokeTest")
         }
         systemProperty("tokenpulse.testMode", "true")
         maxParallelForks = 1

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/CliConnectDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/CliConnectDialog.kt
@@ -75,7 +75,7 @@ abstract class CliConnectDialog(
         }
 
         row {
-            comment(stripHtmlWrapper(spec.descriptionHtml))
+            comment(DslCommentText.sanitize(spec.descriptionHtml))
         }
 
         separator()
@@ -96,7 +96,7 @@ abstract class CliConnectDialog(
         }
 
         row {
-            comment(stripHtmlWrapper(spec.requirementsHtml))
+            comment(DslCommentText.sanitize(spec.requirementsHtml))
         }
 
         separator()
@@ -110,21 +110,6 @@ abstract class CliConnectDialog(
     override fun getPreferredFocusedComponent() = detectButton
 
     // ── HTML helpers ────────────────────────────────────────────────────────
-
-    /**
-     * Strips outer <html>...</html> wrapper if present.
-     * Needed because Row.comment() already wraps text in <html> internally.
-     */
-    private fun stripHtmlWrapper(text: String): String {
-        val trimmed = text.trim()
-        return if (trimmed.startsWith("<html>", ignoreCase = true) &&
-            trimmed.endsWith("</html>", ignoreCase = true)
-        ) {
-            trimmed.substring(6, trimmed.length - 7)
-        } else {
-            trimmed
-        }
-    }
 
     private fun detectingStatusHtml() =
         "<html><i>Detecting ${spec.cliName}...</i></html>"

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/DslCommentText.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/DslCommentText.kt
@@ -1,0 +1,20 @@
+package org.zhavoronkov.tokenpulse.ui
+
+/**
+ * Sanitizes text for IntelliJ UI DSL calls that wrap their argument in
+ * `<html>...</html>` themselves — `comment()`, `rowComment()`, `text()`,
+ * `contextHelp()` — and reject an explicit `<html>` or `<body>` tag from the
+ * caller at runtime (`DslLabelKt.DENIED_TAGS`): a logged error in
+ * production, a thrown `UiDslException` under tests.
+ *
+ * Removes every `<html>`/`<body>` tag — opening or closing, with or without
+ * attributes, paired or unpaired — case-insensitively. All other tags
+ * (`<br>`, `<b>`, `<code>`, `<a href="...">`, ...) are legal inside these
+ * calls and pass through unchanged.
+ */
+internal object DslCommentText {
+
+    private val htmlOrBodyTag = Regex("</?(html|body)\\b[^>]*>", RegexOption.IGNORE_CASE)
+
+    fun sanitize(text: String): String = htmlOrBodyTag.replace(text, "").trim()
+}

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/XiaomiConnectDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/XiaomiConnectDialog.kt
@@ -146,8 +146,8 @@ class XiaomiConnectDialog : DialogWrapper(true) {
         } else {
             row {
                 comment(
-                    "<html>The embedded browser isn't available in this IDE build, so use " +
-                        "the manual cURL capture below.</html>"
+                    "The embedded browser isn't available in this IDE build, so use " +
+                        "the manual cURL capture below."
                 )
             }
             manualCaptureRows()

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/TokenPulseSmokeTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/TokenPulseSmokeTest.kt
@@ -1,14 +1,17 @@
 package org.zhavoronkov.tokenpulse
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
-import org.junit.jupiter.api.Tag
 import org.zhavoronkov.tokenpulse.service.BalanceRefreshService
 import org.zhavoronkov.tokenpulse.service.HttpClientService
 import org.zhavoronkov.tokenpulse.settings.TokenPulseSettingsService
+import org.zhavoronkov.tokenpulse.ui.CodexConnectDialog
 import org.zhavoronkov.tokenpulse.ui.TokenPulseConfigurable
 import org.zhavoronkov.tokenpulse.ui.TokenPulseDashboardDialog
+import org.zhavoronkov.tokenpulse.ui.XiaomiConnectDialog
 
-@Tag("platform")
+// Routed to the `platformTest` Gradle task by class name (see build.gradle.kts) —
+// not by @Tag, since this is a JUnit 3-style junit.framework.TestCase run
+// through the Vintage engine, which does not honor Jupiter's @Tag.
 class TokenPulseSmokeTest : BasePlatformTestCase() {
 
     fun testServicesAreRegistered() {
@@ -23,8 +26,25 @@ class TokenPulseSmokeTest : BasePlatformTestCase() {
         assertNotNull(component)
     }
 
+    // DialogWrapper.contentPane/contentPanel/title all delegate to the
+    // DialogWrapperPeer, which returns null under this headless platform
+    // test peer even after fully successful construction — so it can't be
+    // used to assert a dialog built correctly. The constructor call not
+    // throwing is the real assertion: DialogWrapper.init() (invoked
+    // synchronously from each dialog's own init {} block) runs
+    // createCenterPanel(), and IntelliJ's UI DSL throws UiDslException the
+    // moment a denied tag (<html>, <body>, empty-href) reaches comment()/
+    // rowComment()/text()/contextHelp() (see DslCommentHtmlGuardTest for the
+    // static-scan equivalent).
     fun testDashboardCreation() {
-        val dialog = TokenPulseDashboardDialog(project)
-        assertNotNull(dialog.contentPane)
+        TokenPulseDashboardDialog(project)
+    }
+
+    fun testCodexConnectDialogCreation() {
+        CodexConnectDialog()
+    }
+
+    fun testXiaomiConnectDialogCreation() {
+        XiaomiConnectDialog()
     }
 }

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/ui/DslCommentHtmlGuardTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/ui/DslCommentHtmlGuardTest.kt
@@ -1,0 +1,140 @@
+package org.zhavoronkov.tokenpulse.ui
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Guards against passing a literal `<html>`/`<body>` tag into an IntelliJ UI
+ * DSL call that wraps its argument in `<html>...</html>` itself and rejects
+ * an explicit one at runtime — logging an error (production) or throwing
+ * `UiDslException` (tests). Verified against the platform's own
+ * `DslLabel`/`DslLabelKt.DENIED_TAGS` check, which guards `comment()`,
+ * `rowComment()`, `text()`, and `contextHelp()`.
+ *
+ * `label(...)` and plain Swing `JBLabel(...)`/`.text = ...` are NOT checked
+ * by the platform and must keep their `<html>` wrapper — this test must
+ * never flag them.
+ */
+class DslCommentHtmlGuardTest {
+
+    private val guardedFunctions = setOf("comment", "rowComment", "text", "contextHelp")
+    private val deniedTagPattern = Regex("<(html|body)\\b", RegexOption.IGNORE_CASE)
+
+    @Test
+    fun `no literal html or body tag reaches a UI DSL comment-like call`() {
+        val root = File("src/main/kotlin")
+        check(root.isDirectory) { "expected $root to exist relative to the module working directory" }
+
+        val violations = root.walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .flatMap { file -> findViolations(file).asSequence() }
+            .toList()
+
+        assertTrue(
+            violations.isEmpty(),
+            "Literal <html>/<body> passed into a UI DSL call that rejects it at runtime:\n" +
+                violations.joinToString("\n")
+        )
+    }
+
+    private fun findViolations(file: File): List<String> {
+        val source = file.readText()
+        return findCallArgumentSpans(source, guardedFunctions)
+            .filter { (_, arg) -> deniedTagPattern.containsMatchIn(arg) }
+            .map { (line, _) -> "${file.path}:$line" }
+    }
+
+    /**
+     * If [source] at [start] begins a string literal or a comment, returns
+     * the index just past its end; otherwise null. Shared by the top-level
+     * scan and by [findMatchingClose] so both agree on what counts as code.
+     */
+    private fun skipStringOrComment(source: String, start: Int): Int? {
+        val n = source.length
+        return when {
+            source.startsWith("\"\"\"", start) -> {
+                var i = start + 3
+                while (i < n && !source.startsWith("\"\"\"", i)) i++
+                (i + 3).coerceAtMost(n)
+            }
+            source[start] == '"' -> {
+                var i = start + 1
+                while (i < n && source[i] != '"') i += if (source[i] == '\\') 2 else 1
+                (i + 1).coerceAtMost(n)
+            }
+            source[start] == '\'' -> {
+                var i = start + 1
+                while (i < n && source[i] != '\'') i += if (source[i] == '\\') 2 else 1
+                (i + 1).coerceAtMost(n)
+            }
+            source.startsWith("//", start) -> {
+                var i = start
+                while (i < n && source[i] != '\n') i++
+                i
+            }
+            source.startsWith("/*", start) -> {
+                var i = start + 2
+                while (i < n && !source.startsWith("*/", i)) i++
+                (i + 2).coerceAtMost(n)
+            }
+            else -> null
+        }
+    }
+
+    /** Index of the `)` matching the `(` at [openParenIndex], skipping nested calls/strings/comments. */
+    private fun findMatchingClose(source: String, openParenIndex: Int): Int {
+        val n = source.length
+        var depth = 1
+        var i = openParenIndex + 1
+        while (i < n && depth > 0) {
+            val skipTo = skipStringOrComment(source, i)
+            if (skipTo != null) {
+                i = skipTo
+                continue
+            }
+            when (source[i]) {
+                '(' -> depth++
+                ')' -> depth--
+            }
+            i++
+        }
+        return i - 1
+    }
+
+    /** Finds every call to a name in [functionNames], returning (1-based line, raw text between its parens). */
+    private fun findCallArgumentSpans(source: String, functionNames: Set<String>): List<Pair<Int, String>> {
+        val results = mutableListOf<Pair<Int, String>>()
+        val n = source.length
+        fun isIdentChar(c: Char) = c.isLetterOrDigit() || c == '_'
+
+        var i = 0
+        while (i < n) {
+            val skipTo = skipStringOrComment(source, i)
+            if (skipTo != null) {
+                i = skipTo
+                continue
+            }
+            val c = source[i]
+            if (isIdentChar(c) && (i == 0 || !isIdentChar(source[i - 1]))) {
+                var j = i
+                while (j < n && isIdentChar(source[j])) j++
+                val ident = source.substring(i, j)
+                var k = j
+                while (k < n && source[k] == ' ') k++
+                if (ident in functionNames && k < n && source[k] == '(') {
+                    val closeIdx = findMatchingClose(source, k)
+                    val arg = source.substring(k + 1, closeIdx.coerceIn(k + 1, n))
+                    val line = 1 + source.substring(0, i).count { it == '\n' }
+                    results.add(line to arg)
+                    i = closeIdx + 1
+                    continue
+                }
+                i = j
+                continue
+            }
+            i++
+        }
+        return results
+    }
+}

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/ui/DslCommentTextTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/ui/DslCommentTextTest.kt
@@ -1,0 +1,45 @@
+package org.zhavoronkov.tokenpulse.ui
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class DslCommentTextTest {
+
+    @Test
+    fun `strips a matched html pair`() {
+        assertEquals("hello world", DslCommentText.sanitize("<html>hello world</html>"))
+    }
+
+    @Test
+    fun `strips an unpaired opening html tag`() {
+        assertEquals("hello world", DslCommentText.sanitize("<html>hello world"))
+    }
+
+    @Test
+    fun `strips an attributed html tag`() {
+        assertEquals("hello", DslCommentText.sanitize("<html lang=\"en\">hello</html>"))
+    }
+
+    @Test
+    fun `strips body tags`() {
+        assertEquals("hello", DslCommentText.sanitize("<html><body>hello</body></html>"))
+    }
+
+    @Test
+    fun `is case insensitive`() {
+        assertEquals("hello", DslCommentText.sanitize("<HTML><Body>hello</BODY></html>"))
+    }
+
+    @Test
+    fun `preserves inner tags`() {
+        assertEquals(
+            "line one<br>line <b>two</b>",
+            DslCommentText.sanitize("<html>line one<br>line <b>two</b></html>")
+        )
+    }
+
+    @Test
+    fun `leaves plain text unchanged`() {
+        assertEquals("just plain text", DslCommentText.sanitize("just plain text"))
+    }
+}


### PR DESCRIPTION
## Summary

**The reported bug** (a user's IDE crash-report balloon):
```
Invalid html: tag <html> inserted automatically and shouldn't be used, text:
<html>Claude Code uses the Claude CLI for authentication...
```
IntelliJ's UI DSL `comment()`/`rowComment()`/`text()`/`contextHelp()` wrap their argument in `<html>` themselves and reject an explicit `<html>`/`<body>` tag from the caller at runtime (`DslLabelKt.DENIED_TAGS`) — a logged IDE error in production, a thrown `UiDslException` under tests. The originally reported `ClaudeConnectDialog` no longer exists (replaced by an inline OAuth flow), but the same bug pattern was still live in `XiaomiConnectDialog`'s JCEF-unavailable branch, which passed a literal `<html>...</html>` wrapper straight into `comment()`.

- Fixed the live defect in `XiaomiConnectDialog.kt`.
- Extracted `CliConnectDialog`'s private `stripHtmlWrapper` into a shared, unit-tested `DslCommentText.sanitize()` that also strips unpaired/attributed `<html>`/`<body>` tags, which the original only-matched-pairs helper missed.
- Added `DslCommentHtmlGuardTest`, a source-scanning regression test over every DSL call site of this class, so the next occurrence is caught by `./gradlew test` instead of a user.

**A second, unrelated bug found while building the regression test:** `platformTest` (which `check`/CI depends on) had never actually executed a single test. `TokenPulseSmokeTest` extends IntelliJ's `BasePlatformTestCase` — a JUnit 3-style `TestCase` — routed via a Jupiter `@Tag`, which the Vintage engine (the JUnit3/4 bridge) does not honor. The class was silently excluded from `test` and silently unmatched by `platformTest`'s own tag filter, so `check` has been reporting green on zero platform assertions.

- Added the missing `junit-vintage-engine` dependency.
- Switched the `test`/`platformTest` split from tag-based to class-name-based filtering.
- Gave `platformTest` the same IntelliJ sandbox JVM wiring (`IntelliJPlatformArgumentProvider`, `SandboxArgumentProvider`, rearranged classpath, custom `javaLauncher`) that the platform Gradle plugin only auto-attaches to the task literally named `test`, since a manually registered `Test` task doesn't inherit it.
- Dropped `DialogWrapper.contentPane`-based assertions across `TokenPulseSmokeTest` (including the pre-existing `testDashboardCreation`, now exposed as never having actually run) — `contentPane` fully delegates to the peer, which returns null under this headless test peer even after fully successful construction. The real assertion is the dialog constructor not throwing.
- Added `testCodexConnectDialogCreation`/`testXiaomiConnectDialogCreation` as a real-platform oracle for dialog construction.

## Test plan
- [x] `./gradlew clean test platformTest koverVerify` — all green (742 unit tests, 5 platform tests, 0 failures).
- [x] Verified `DslCommentHtmlGuardTest` goes red on the original `XiaomiConnectDialog.kt` bug and green after the fix.
- [x] Verified `platformTest` genuinely discovers and runs `TokenPulseSmokeTest` (previously silently ran 0 tests) — confirmed via `--info` engine discovery output before/after.
- [x] Manually verify in a running IDE (`./gradlew runIde`) that adding a Xiaomi account on a JCEF-unavailable build shows no error balloon.

Note: `./gradlew detekt` currently fails locally with an unrelated JVM-version crash (Gradle daemon's own JDK 26 vs detekt 1.23.8) — confirmed pre-existing on `main` before this branch, unaffected by this change.