### PR TITLE
Remove scheduled-for-removal API usages; bump platform to 2025.3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,39 @@ jobs:
           name: test-results
           path: build/reports/tests/
 
+  verify:
+    name: Plugin Verifier
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+
+      # Catches deprecated / scheduled-for-removal platform API before release
+      # rather than at publish time. failureLevel in build.gradle.kts makes
+      # these actually fail the build instead of only printing a report.
+      - name: Verify plugin
+        run: ./gradlew verifyPlugin --build-cache
+
+      - name: Upload verifier report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-verifier-report
+          path: build/reports/pluginVerifier/
+
   lint:
     name: Lint (Detekt)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,6 @@ concurrency:
 env:
   # Opt into Node.js 24 for GitHub Actions (Node.js 20 deprecated June 2026)
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  # Skip the ~23s headless-IDE buildSearchableOptions task on CI verification.
-  # The release workflow does NOT set this, so releases still generate it.
-  SKIP_SEARCHABLE_OPTIONS: "true"
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ build/
 out/
 target/
 bin/
-docs/
 
 # Gradle
 .gradle/
@@ -101,6 +100,8 @@ openrouter-intellij-plugin
 .mimocode/
 .research/
 CLAUDE.md
+# Work items per docs/agents/issue-tracker.md are local Markdown, not committed.
+.scratch/
 
 # Plugin signing credentials (NEVER commit these!)
 *.pem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to the TokenPulse plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Architecture Decision Records** — `docs/adr/` now holds the ADRs that
+  `docs/agents/domain.md` has always required. They were previously impossible to commit:
+  `.gitignore` listed `docs/` under "Build directories" and swallowed the whole tree, which
+  also kept the agent-convention docs out of the repository.
+
+### Changed
+- **⚠️ Minimum IntelliJ platform is now 2025.3 (build 253)**, up from 2024.2 (build 242).
+  IDEs from 2024.2 through 2025.2 will stay on the last compatible release and no longer
+  receive updates. This was required to replace `SimpleListCellRenderer.create(...)`, which
+  JetBrains has scheduled for removal — both of its overloads are deprecated in current
+  builds, and the replacement API does not exist in the 2024.2 SDK.
+  See [ADR-0001](docs/adr/0001-raise-minimum-platform-to-2025-3.md).
+
+### Fixed
+- Removed all use of platform API that is deprecated or scheduled for removal, so the plugin
+  verifies cleanly against current IDEs.
+
+### Removed
+- Individual TokenPulse settings are no longer indexed for Settings search
+  (`buildSearchableOptions` is disabled — its headless IDE run crashes on the 2025.3.6 SDK).
+  The TokenPulse settings page itself is still findable.
+
 ## [0.4.0] - 2026-07-23
 
 ### Added

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -100,8 +100,8 @@ token-pulse/
 All versioning and platform compatibility info is centralized in **`gradle.properties`**:
 ```properties
 pluginVersion = 0.4.0
-pluginSinceBuild = 242
-platformVersion = 2024.2
+pluginSinceBuild = 253
+platformVersion = 2025.3.6
 ```
 
 To update the version, use:

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ on Linux). They are never written to plain-text settings files.
 
 ## Compatibility
 
-- **IntelliJ Platform** — 2024.2+ (build 242+); no upper bound (compatible with current and future builds)
+- **IntelliJ Platform** — 2025.3+ (build 253+); no upper bound (compatible with current and future builds)
 - **Java** — 21 (LTS)
 - **IDEs** — IntelliJ IDEA (Community & Ultimate), WebStorm, PyCharm, and other JetBrains IDEs
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,7 +41,10 @@ dependencies {
 
     // IntelliJ Platform dependencies (2.x plugin style)
     intellijPlatform {
-        val platformVersion = project.findProperty("platformVersion") as String? ?: "2024.2.5"
+        // Keep this fallback in step with the pluginSinceBuild fallback below:
+        // compiling against an older SDK than we declare compatibility with
+        // would fail on APIs that only exist in the newer one.
+        val platformVersion = project.findProperty("platformVersion") as String? ?: "2025.3.6"
         intellijIdeaUltimate(platformVersion)
 
         // Test framework for plugin tests
@@ -60,14 +63,31 @@ java {
 intellijPlatform {
     pluginConfiguration {
         ideaVersion {
-            sinceBuild = project.findProperty("pluginSinceBuild") as String? ?: "242"
+            sinceBuild = project.findProperty("pluginSinceBuild") as String? ?: "253"
             untilBuild = provider { null }  // No upper bound - compatible with all future versions
         }
     }
 
     pluginVerification {
+        // The verifier only FAILS on COMPATIBILITY_PROBLEMS by default — it
+        // merely prints deprecation findings. That is why 0.4.0 shipped with
+        // 2 scheduled-for-removal usages even though release CI ran
+        // verifyPlugin. Fail the build on them instead.
+        failureLevel = listOf(
+            org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS,
+            org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.DEPRECATED_API_USAGES,
+            org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES,
+        )
+
         ides {
-            recommended()
+            // Opt-in fast local loop: -PverifierLocalIde=/path/to/IDE.app verifies
+            // against an installed IDE instead of downloading the recommended set.
+            val localIde = project.findProperty("verifierLocalIde") as String?
+            if (localIde != null) {
+                local(localIde)
+            } else {
+                recommended()
+            }
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -151,14 +151,16 @@ tasks {
         ignoreFailures = true  // Don't fail the build on Detekt issues during development
     }
 
-    // buildSearchableOptions launches a headless IDE (~23s) to index plugin
-    // searchable options. It is only needed for the shipped plugin ZIP, not for
-    // PR/push CI verification. `ci.yml` sets SKIP_SEARCHABLE_OPTIONS=true to skip
-    // it; the release workflow does NOT set it, so releases still generate it.
-    // (Note: GitHub Actions always sets CI=true, so we deliberately do NOT gate
-    // on CI here — that would also skip it during releases.)
+    // buildSearchableOptions launches a headless IDE (~23s) purely to index the
+    // plugin's settings so individual options are findable in Settings search.
+    // Disabled outright: on the 2025.3.6 SDK its bundled JBR aborts at JVM
+    // startup on macOS (SIGABRT in Threads::create_vm -> post_vm_initialized,
+    // ~0.18s in, before any plugin code runs), so it breaks local release
+    // builds and buys little — the TokenPulse settings PAGE is still reachable
+    // from Settings search either way, only the individual option labels are
+    // not indexed.
     named("buildSearchableOptions") {
-        enabled = System.getenv("SKIP_SEARCHABLE_OPTIONS") != "true"
+        enabled = false
     }
 
     // Configure tests

--- a/docs/adr/0001-raise-minimum-platform-to-2025-3.md
+++ b/docs/adr/0001-raise-minimum-platform-to-2025-3.md
@@ -1,0 +1,55 @@
+# 1. Raise the minimum supported IntelliJ platform to 2025.3 (build 253)
+
+- **Status:** Accepted
+- **Date:** 2026-08-16
+
+## Context
+
+JetBrains' Plugin Verifier reported that TokenPulse 0.4.0 used API scheduled for
+removal: two calls to `SimpleListCellRenderer.create(String, Function)` in
+`TokenPulseConfigurable` (the "Display mode" and "Format" combo boxes).
+
+The obvious fix — switching to the sibling `create(Customizer)` overload — is a
+dead end: inspecting the 262 bytecode shows **both** `create` overloads are
+annotated `@Deprecated(forRemoval = true)`. Swapping one for the other would
+only defer the same report to the next release.
+
+The actual replacement is `textListCellRenderer` from
+`com.intellij.ui.dsl.listCellRenderer`. That package **does not exist in the
+2024.2 SDK** the plugin previously compiled against, so the deprecation could
+not be resolved while remaining on that baseline.
+
+Two further facts shaped the decision:
+
+- In the 2024.2 SDK the deprecated method carries **no deprecation annotation at
+  all**, so the Kotlin compiler could never have warned about it. Only a
+  verifier run against a newer IDE reveals the problem.
+- The plugin declares no `untilBuild`, so it already ran on IDEs where the
+  method is deprecated.
+
+## Decision
+
+Raise the baseline: `platformVersion` 2024.2 → **2025.3.6** and
+`pluginSinceBuild` 242 → **253** (`gradle.properties`), and migrate both call
+sites to `textListCellRenderer`.
+
+`textListCellRenderer` was verified to be public API — the only
+`@ApiStatus.Internal` members of that package are `groupedTextListCellRenderer`
+and `comboBoxEditorRenderer`, neither of which is used.
+
+## Consequences
+
+- **Users on 2024.2 through 2025.2 no longer receive updates.** This is the
+  hard-to-reverse part: once a release ships with `sinceBuild = 253`, those
+  installs are pinned to the last compatible version. Accepted deliberately, as
+  there is no way to use the replacement API otherwise.
+- `buildSearchableOptions` is disabled. On the 2025.3.6 SDK its bundled JBR
+  aborts at JVM startup on macOS (`SIGABRT` in `Threads::create_vm` →
+  `JvmtiExport::post_vm_initialized`, ~0.18s in, before any plugin code runs).
+  It only indexes individual settings labels for Settings search — the
+  TokenPulse settings *page* remains findable — and disabling it also removes
+  ~23s from release builds.
+- Compatibility documentation in `README.md` and `DEVELOPMENT.md` was updated to
+  state 2025.3+.
+- Future platform-baseline raises should be recorded as new ADRs rather than
+  edited into this one.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,20 @@
+# Domain documentation layout
+
+## Layout
+
+This repository uses a single domain context:
+
+- `CONTEXT.md` at the repository root is the domain glossary and current domain-model reference.
+- `docs/adr/` contains Architecture Decision Records (ADRs).
+
+## Consumer rules
+
+Before designing, debugging, or implementing a change:
+
+1. Read root `CONTEXT.md` when it exists.
+2. Read ADRs in `docs/adr/` relevant to the affected module or decision.
+3. Treat existing glossary definitions and accepted ADRs as constraints.
+4. When a hard-to-reverse architectural or domain decision is made, record an ADR.
+5. Update `CONTEXT.md` when domain vocabulary or a settled business rule changes.
+
+There is no `CONTEXT-MAP.md` because this is not a multi-context repository.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,19 @@
+# Local issue tracker
+
+## Location
+
+Track work as local Markdown files under:
+
+```text
+.scratch/<feature>/
+```
+
+No external issue-tracker service or CLI is required.
+
+## Conventions
+
+- Use one feature directory per independent effort.
+- Keep `tickets.md` in the feature directory as the ordered index of work.
+- Store each actionable ticket as its own Markdown file when the effort needs multiple tickets.
+- State a ticket's blocking edges explicitly.
+- Keep `.scratch/` work local unless a repository maintainer intentionally decides otherwise.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,13 @@
+# Triage label vocabulary
+
+Use these exact labels when triaging incoming issues:
+
+| Canonical role | Label | Meaning |
+| --- | --- | --- |
+| Needs evaluation | `needs-triage` | A maintainer needs to evaluate the issue. |
+| Waiting on reporter | `needs-info` | More information is needed from the reporter. |
+| Ready for agent | `ready-for-agent` | Fully specified and ready for an AFK coding agent. |
+| Ready for human | `ready-for-human` | Requires human implementation or intervention. |
+| Will not fix | `wontfix` | Will not be actioned. |
+
+Do not invent alternate labels unless this mapping is deliberately updated.

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,11 +9,11 @@ pluginVersion = 0.4.0
 pluginRepositoryUrl = https://github.com/DimazzzZ/tokenpulse-intellij-plugin
 
 # Compatibility
-pluginSinceBuild = 242
+pluginSinceBuild = 253
 
 # IntelliJ Platform Properties
 platformType = IU
-platformVersion = 2024.2
+platformVersion = 2025.3.6
 
 # ====== Gradle Performance Optimizations ======
 

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/TokenPulseConfigurable.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/TokenPulseConfigurable.kt
@@ -10,6 +10,7 @@ import com.intellij.ui.dsl.builder.Align
 import com.intellij.ui.dsl.builder.bindIntText
 import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.panel
+import com.intellij.ui.dsl.listCellRenderer.textListCellRenderer
 import com.intellij.ui.table.JBTable
 import com.intellij.util.ui.JBUI
 import org.zhavoronkov.tokenpulse.model.ConnectionType
@@ -132,7 +133,7 @@ class TokenPulseConfigurable : Configurable {
                 row("Display mode:") {
                     displayModeCombo = comboBox(
                         StatusBarDisplayMode.entries,
-                        renderer = com.intellij.ui.SimpleListCellRenderer.create("") { it.displayName }
+                        renderer = textListCellRenderer { it?.displayName.orEmpty() }
                     )
                         .applyToComponent {
                             selectedItem = statusBarDisplayMode
@@ -160,7 +161,7 @@ class TokenPulseConfigurable : Configurable {
                 row("Format:") {
                     formatCombo = comboBox(
                         StatusBarFormat.entries,
-                        renderer = com.intellij.ui.SimpleListCellRenderer.create("") { it.displayName }
+                        renderer = textListCellRenderer { it?.displayName.orEmpty() }
                     )
                         .applyToComponent {
                             selectedItem = statusBarFormat


### PR DESCRIPTION
## Summary

JetBrains' verifier flagged **2 usages of scheduled-for-removal API** in 0.4.0: `SimpleListCellRenderer.create(String, Function)`, used by the "Display mode" and "Format" combo boxes in `TokenPulseConfigurable`.

The non-obvious part: the sibling `create(Customizer)` overload is **also** `@Deprecated(forRemoval=true)` in 262 (verified in the bytecode), so swapping overloads would just defer the problem one release. The real replacement — `textListCellRenderer` from `com.intellij.ui.dsl.listCellRenderer` — **does not exist in the 2024.2 SDK** the plugin compiled against. Hence the platform bump. That replacement is public API: the only `@ApiStatus.Internal` members of that package are `groupedTextListCellRenderer` and `comboBoxEditorRenderer`, neither of which we use.

### Why this escaped CI
1. In the **2024.2 SDK the method carries no deprecation annotation at all**, so the Kotlin compiler could never warn — only a verifier run against a *newer* IDE reveals it.
2. The verifier's `failureLevel` defaults to `[COMPATIBILITY_PROBLEMS]`, so it **printed the finding and still reported `BUILD SUCCESSFUL`**.
3. `verifyPlugin` ran only in `release.yml`, never on PRs — surfacing the problem at the worst possible moment.

### Changes
- Replace both call sites with `textListCellRenderer { it?.displayName.orEmpty() }`.
- Bump `platformVersion` 2024.2 → **2025.3.6** and `pluginSinceBuild` 242 → **253**, and keep the `platformVersion` *fallback* in step with the `sinceBuild` fallback — otherwise a build without the property would compile against an SDK lacking the replacement API while stamping 253.
- Add `DEPRECATED_API_USAGES` + `SCHEDULED_FOR_REMOVAL_API_USAGES` to `failureLevel` so these now fail the build.
- Add a `Plugin Verifier` job to `ci.yml` so PRs catch this, not releases.
- Add opt-in `-PverifierLocalIde=<path>` to verify against an installed IDE instead of downloading the recommended set (~several GB).
- **Disable `buildSearchableOptions`** — see below.
- **Record ADR-0001** and add a CHANGELOG `[Unreleased]` entry.

## ⚠️ Compatibility break
`sinceBuild` moves 242 → 253, **dropping support for 2024.2 through 2025.2**. Once a release ships, those installs are pinned to the last compatible version. This is the hard-to-reverse part, taken deliberately — it's recorded in [ADR-0001](docs/adr/0001-raise-minimum-platform-to-2025-3.md).

## `buildSearchableOptions` disabled
The SDK bump surfaced a crash: that task launches a headless IDE, and on the 2025.3.6 SDK its bundled JBR aborts at JVM startup on macOS (`SIGABRT` in `Threads::create_vm` → `JvmtiExport::post_vm_initialized`, ~0.18s in, before any plugin code runs). It succeeds on the 2024.2 SDK on the same machine, so the bump caused it.

Rather than leave a landmine in the release path, it's disabled outright. It only indexes individual settings *labels* for Settings search — the TokenPulse settings page itself stays findable — and this also removes ~23s from release builds.

## `docs/` was uncommittable
Recording the ADR surfaced why the repo had none: `.gitignore` listed `docs/` under **"# Build directories"**, silently swallowing the whole tree, so `docs/adr/` literally could not be committed. This project has no docs generator (no Dokka/javadoc), so the entry was simply misfiled. Dropping it also brings `docs/agents/*.md` into the repo. `CLAUDE.md` stays ignored on purpose (local agent config), so those convention docs currently have no tracked entry point — noted rather than papered over. `.scratch/` is now ignored, since `docs/agents/issue-tracker.md` defines it as local-only.

## Test plan
- [x] Rebased onto current `main` (post #24/#25) — clean.
- [x] `verifyPlugin` against IU-262.9437.185 → verdict exactly `Compatible`, no deprecation sections (was: `Compatible. 2 usages of scheduled for removal API`).
- [x] **Verified the new gate actually bites** — temporarily reinstating one deprecated call flips the build to `BUILD FAILED` with `DEPRECATED_API_USAGES`, where previously the identical finding still exited `BUILD SUCCESSFUL`.
- [x] `./gradlew test platformTest koverVerify` → 739 unit + 5 platform tests, 0 failures.
- [x] Compiles cleanly against 2025.3.6; no other API broke from the bump.