### PR TITLE
Fail the build on internal & experimental platform API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   JetBrains has scheduled for removal — both of its overloads are deprecated in current
   builds, and the replacement API does not exist in the 2024.2 SDK.
   See [ADR-0001](docs/adr/0001-raise-minimum-platform-to-2025-3.md).
+- **Non-public platform API is now a build failure, not a warning** — the Plugin Verifier gate
+  covers internal, experimental, override-only and non-extendable API alongside deprecated and
+  scheduled-for-removal usages. The plugin is already clean, so this is a guard against
+  regressions. `MISSING_DEPENDENCIES` and `NOT_DYNAMIC` are deliberately excluded because they
+  report unavailable *optional* dependencies we don't control.
+  See [ADR-0002](docs/adr/0002-no-non-public-platform-api.md).
 
 ### Fixed
 - Removed all use of platform API that is deprecated or scheduled for removal, so the plugin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel
+
 plugins {
     id("java")
     kotlin("jvm") version "2.1.20"
@@ -70,13 +72,25 @@ intellijPlatform {
 
     pluginVerification {
         // The verifier only FAILS on COMPATIBILITY_PROBLEMS by default — it
-        // merely prints deprecation findings. That is why 0.4.0 shipped with
-        // 2 scheduled-for-removal usages even though release CI ran
-        // verifyPlugin. Fail the build on them instead.
+        // merely prints everything else. That is why 0.4.0 shipped with 2
+        // scheduled-for-removal usages even though release CI ran
+        // verifyPlugin. Fail the build on the whole non-public-API surface
+        // instead: JetBrains penalizes plugins that reach into internal or
+        // experimental platform API, and the plugin is currently clean, so
+        // this is a guard against regressions rather than a migration.
+        //
+        // MISSING_DEPENDENCIES and NOT_DYNAMIC are deliberately NOT included:
+        // the report already lists unavailable *optional* dependencies (e.g.
+        // com.intellij.jetbrains.client) that we do not control, so they
+        // would fail spuriously.
         failureLevel = listOf(
-            org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.COMPATIBILITY_PROBLEMS,
-            org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.DEPRECATED_API_USAGES,
-            org.jetbrains.intellij.platform.gradle.tasks.VerifyPluginTask.FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES,
+            FailureLevel.COMPATIBILITY_PROBLEMS,
+            FailureLevel.DEPRECATED_API_USAGES,
+            FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES,
+            FailureLevel.INTERNAL_API_USAGES,
+            FailureLevel.EXPERIMENTAL_API_USAGES,
+            FailureLevel.OVERRIDE_ONLY_API_USAGES,
+            FailureLevel.NON_EXTENDABLE_API_USAGES,
         )
 
         ides {

--- a/docs/adr/0002-no-non-public-platform-api.md
+++ b/docs/adr/0002-no-non-public-platform-api.md
@@ -1,0 +1,74 @@
+# 2. Forbid non-public IntelliJ Platform API and enforce it in the verifier
+
+- **Status:** Accepted
+- **Date:** 2026-08-16
+
+## Context
+
+JetBrains penalizes plugins that reach into non-public platform API, and
+Marketplace review flags it. The risk is not hypothetical for this project: the
+platform baseline raise in [ADR-0001](0001-raise-minimum-platform-to-2025-3.md)
+was forced by a scheduled-for-removal API that shipped in 0.4.0 unnoticed.
+
+Three separate gaps let that happen:
+
+1. In the SDK the plugin compiled against, the offending method carried **no
+   deprecation annotation at all**, so the Kotlin compiler could not warn. Only
+   a verifier run against a *newer* IDE reveals such problems.
+2. The Plugin Verifier's `failureLevel` defaults to `COMPATIBILITY_PROBLEMS`
+   only. It printed the finding and still exited successfully.
+3. `verifyPlugin` ran only in the release workflow, so the report appeared at
+   publish time rather than on the pull request that introduced it.
+
+An audit at the time this ADR was written found the plugin **clean**: the
+verifier verdict is `Compatible` and it emits no internal, experimental, or
+deprecated usage reports. So this is a guard against regression, not a
+migration.
+
+## Decision
+
+Fail the build on the whole non-public-API surface, not just compatibility
+breakage. `intellijPlatform.pluginVerification.failureLevel` enumerates:
+
+- `COMPATIBILITY_PROBLEMS`
+- `DEPRECATED_API_USAGES`
+- `SCHEDULED_FOR_REMOVAL_API_USAGES`
+- `INTERNAL_API_USAGES`
+- `EXPERIMENTAL_API_USAGES`
+- `OVERRIDE_ONLY_API_USAGES`
+- `NON_EXTENDABLE_API_USAGES`
+
+`MISSING_DEPENDENCIES` and `NOT_DYNAMIC` are **deliberately excluded**: the
+verifier report already lists unavailable *optional* dependencies (for example
+`com.intellij.jetbrains.client`) that this project does not control, so
+including them would fail spuriously.
+
+`verifyPlugin` also runs on pull requests, not only on release.
+
+## Consequences
+
+- Any future use of `@ApiStatus.Internal` / `@ApiStatus.Experimental` API, or of
+  anything deprecated or scheduled for removal, **fails CI**. Treat this as a
+  constraint when choosing platform APIs: prefer a public alternative, and if
+  none exists, raise the platform baseline (new ADR) rather than reaching for
+  internal API.
+- The gate was verified to actually fire, not merely configured: temporarily
+  calling `groupedTextListCellRenderer` (which *is* `@ApiStatus.Internal`,
+  unlike the `textListCellRenderer` this plugin uses) turns the build red with
+  `1 usage of internal API`.
+- **Reflection is outside this gate.** `OpenRouterPluginBridgeClient` reflects
+  into another *plugin's* service class; that is not platform API, so the
+  verifier cannot see it in either direction. It is guarded and degrades to
+  "plugin not installed" on any failure, and must stay that way.
+- Deprecations surface only against *newer* IDEs — the call that forced
+  ADR-0001 carries no annotation at all in the oldest build we support. The gate
+  is therefore only meaningful when verification runs against a recent IDE.
+  Splitting that (pull requests verifying the newest supported build, releases
+  sweeping every supported line) is the agreed follow-up and is implemented
+  separately; at the time this ADR was accepted, CI still ran the unpinned
+  `recommended()` set everywhere.
+
+## Related
+
+- [ADR-0001](0001-raise-minimum-platform-to-2025-3.md) — the platform baseline
+  raise whose root cause this gate is meant to catch earlier next time.

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/openrouter/OpenRouterPluginBridgeClient.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/openrouter/OpenRouterPluginBridgeClient.kt
@@ -18,6 +18,15 @@ import org.zhavoronkov.tokenpulse.utils.TokenPulseLogger
  *
  * Requirements:
  * - OpenRouter plugin (org.zhavoronkov.openrouter) must be installed and configured
+ *
+ * NOTE ON REFLECTION: the reflection here targets *another plugin's* service
+ * class, never IntelliJ Platform API. It is therefore not the internal-API
+ * usage the Plugin Verifier forbids (see the `failureLevel` config in
+ * build.gradle.kts, which fails the build on INTERNAL_API_USAGES) — but it is
+ * also invisible to the verifier, so it cannot be machine-checked. Every
+ * lookup is guarded and degrades to "plugin not installed" on any failure;
+ * keep it that way, since the target plugin can rename or remove these
+ * members at any time without breaking our build.
  */
 class OpenRouterPluginBridgeClient : ProviderClient {
 


### PR DESCRIPTION
> Stacked on #26 — review/merge that first. Base is `fix/deprecated-list-cell-renderer`, so this PR's diff shows only its own commits.

## Summary

JetBrains penalizes plugins that reach into non-public platform API, so this makes that mechanically impossible to reintroduce.

**Important finding: there was nothing to remove.** A verifier run against IU-262.9437.185 gives verdict `Compatible` and emits *no* `internal-api-usages.txt` / `experimental-api-usages.txt` / `deprecated-usages.txt` — only `dependencies/telemetry/verdict`. A source scan also found zero internal-package imports. So this PR is a **regression guard**, not a migration, and is a no-op on the current tree.

### Changes
- Extend the verifier `failureLevel` with `INTERNAL_API_USAGES`, `EXPERIMENTAL_API_USAGES`, `OVERRIDE_ONLY_API_USAGES`, `NON_EXTENDABLE_API_USAGES` (on top of the compatibility/deprecated/scheduled-for-removal levels from #26).
- Deliberately **excluded**: `MISSING_DEPENDENCIES` and `NOT_DYNAMIC`. The report already lists unavailable *optional* dependencies (e.g. `com.intellij.jetbrains.client`) that we don't control — including them would fail spuriously.
- **Record [ADR-0002](docs/adr/0002-no-non-public-platform-api.md).** `docs/agents/domain.md` rule 3 makes accepted ADRs binding constraints, so a standing rule like this belongs somewhere more discoverable than a `build.gradle.kts` comment.
- Document why the reflection in `OpenRouterPluginBridgeClient` is *not* an instance of this problem: it targets another **plugin's** service class, not platform API, so the verifier can't see it in either direction. Every lookup is already guarded and degrades to "plugin not installed".

## Test plan
- [x] `verifyPlugin` with the stricter gate on the clean tree → still exactly `Compatible`.
- [x] **Verified the gate bites, rather than assuming it.** Temporarily calling `groupedTextListCellRenderer` (which *is* `@ApiStatus.Internal` in that same package, unlike the `textListCellRenderer` we use) produces:
  ```
  Compatible. 1 usage of internal API
  > INTERNAL_API_USAGES: Plugin uses API marked as internal (ApiStatus.@Internal).
  BUILD FAILED
  ```
  and returns to green once reverted.

## Note on ADR wording
ADR-0002's consequence about deprecations only surfacing on newer IDEs is written as the **agreed follow-up**, not as current behaviour — splitting PR-vs-release verification lands in #29. An ADR is a binding constraint, so it shouldn't describe CI that doesn't exist yet.