### PR TITLE
Speed up local builds: configuration cache, pinned daemon JVM, working detekt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
           # read-only for untrusted fork PRs so they can't poison the cache.
           cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
 
+      # Note: this invocation always discards the configuration cache, because
+      # koverVerify pulls in every Test task including platformTest, which is
+      # opted out of CC (see build.gradle.kts). Splitting the tasks across steps
+      # does not help for the same reason. CC pays off locally, not here.
       - name: Test
         run: ./gradlew test platformTest koverVerify --build-cache
 
@@ -106,7 +110,7 @@ jobs:
           cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
 
       - name: Detekt
-        run: ./gradlew detekt detektSarif --build-cache
+        run: ./gradlew detekt --build-cache
 
       - name: Detekt SARIF diagnostics
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   regressions. `MISSING_DEPENDENCIES` and `NOT_DYNAMIC` are deliberately excluded because they
   report unavailable *optional* dependencies we don't control.
   See [ADR-0002](docs/adr/0002-no-non-public-platform-api.md).
+- **Detekt now gates the build** — it previously ran with `ignoreFailures = true`, so lint could
+  never fail anything, and it crashed outright on a JDK 26 Gradle daemon. The daemon is now
+  pinned to Java 21 via `gradle/gradle-daemon-jvm.properties`, the duplicate `detektSarif` task
+  is folded into `detekt`, and code-scanning coverage now includes test sources.
+- **Configuration cache is enabled** for local builds — the blocker was this build capturing the
+  `Project` inside `processResources`, not the IntelliJ plugin. `platformTest` is opted out, and
+  because `koverVerify` depends on every test task, the cache benefits local loops rather than CI.
 
 ### Fixed
 - Removed all use of platform API that is deprecated or scheduled for removal, so the plugin

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -38,8 +38,8 @@ For day-to-day development, use the fast build script to skip slow analysis task
 # Run all tests
 ./gradlew test
 
-# Run static analysis
-./gradlew detekt detektSarif
+# Run static analysis (also emits the SARIF report)
+./gradlew detekt
 ```
 
 > **💡 Tip:** The Gradle daemon keeps builds fast. Always use `./gradlew` commands 
@@ -54,13 +54,15 @@ For day-to-day development, use the fast build script to skip slow analysis task
 ./gradlew runIde
 ```
 
-> **Java 21 required for runs.** The `gradle.properties` file pins the Kotlin compiler and Gradle
-> daemon to Java 21. If `./gradlew runIde` fails with a JDK version error, verify your active JDK:
+> **Java 21 required for runs.** `gradle/gradle-daemon-jvm.properties` pins the Gradle *daemon* to
+> Java 21 (by criteria, so any installed JDK 21 is auto-detected), and `gradle.properties` runs the
+> Kotlin compiler inside that daemon. Detekt also runs in the daemon and fails on newer JDKs, so
+> this pin is what keeps `./gradlew detekt` working. If a Gradle run fails with a JDK version error,
+> verify what it actually picked:
 > ```bash
-> java -version   # must show 21.x
-> ./gradlew -version  # shows the JDK Gradle is using
+> ./gradlew -version  # "Daemon JVM" must resolve to Java 21
 > ```
-> On macOS with multiple JDKs installed, set `JAVA_HOME` explicitly before running Gradle.
+> If no JDK 21 is installed, Gradle cannot satisfy the criteria — install one (e.g. Zulu 21).
 
 ## 🏗️ Project Architecture
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -13,6 +13,7 @@ TokenPulse uses **JUnit 5** and **Kotlin Coroutines Test**.
 | **Functional Tests** | `*FunctionalTest.kt` | Require external tools (CLI, etc.) |
 | **Live Tests** | `*LiveTest.kt` | Require real API credentials |
 | **Smoke Tests** | `*SmokeTest.kt` | Require IntelliJ Platform |
+| **Guard Tests** | `*GuardTest.kt` | Scan `src/main` sources for a banned pattern rather than executing code |
 
 ## 🚀 Running Tests
 
@@ -87,9 +88,11 @@ src/test/kotlin/org/zhavoronkov/tokenpulse/
 ├── ui/
     ├── AccountTableColumnsTest.kt      # Unit: pure column-value helpers
     ├── BalanceFormatterTest.kt         # Unit: formatting (17)
+    ├── DslCommentHtmlGuardTest.kt      # Guard: scans src/main for <html> passed to UI DSL comment()
+    ├── DslCommentTextTest.kt           # Unit: DslCommentText.sanitize()
     ├── NebiusCurlParserTest.kt         # Unit: parsing
     ├── NormalizedConfigDirTest.kt      # Unit: Claude config-dir canonicalization
-    ├── ProgressBarRendererTest.kt      # Unit: progress bars (17)
+    ├── ProgressBarRendererTest.kt      # Unit: progress bar colors (remaining%)
     ├── SecretRedactorTest.kt           # Unit: redaction (16)
     └── TooltipModelTest.kt             # Unit: tooltip row grouping/construction per provider
 └── utils/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,19 @@ plugins {
 group = project.findProperty("pluginGroup") ?: "org.zhavoronkov.tokenpulse"
 version = project.findProperty("pluginVersion") ?: "0.1.0"
 
+// Read into a local first: referencing `version` inside the task action would
+// capture the Project itself, which the configuration cache cannot serialize
+// ("cannot serialize object of type 'DefaultProject'") and which was the only
+// thing blocking configuration cache for this build.
+val pluginVersionValue = version.toString()
+
 tasks.processResources {
+    // Re-bind to a local inside the task configuration block: a top-level
+    // `val` in a .kts script is a field on the script object, so referencing
+    // it directly from the action lambda below captures the script itself
+    // ("cannot serialize Gradle script object references"). Capturing a plain
+    // local does not.
+    val version = pluginVersionValue
     filesMatching("tokenpulse.properties") {
         expand("pluginVersion" to version)
     }
@@ -124,29 +136,24 @@ detekt {
     basePath = projectDir.absolutePath
 }
 
-// Configure Detekt SARIF reporting task
-tasks.register<io.gitlab.arturbosch.detekt.Detekt>("detektSarif") {
-    description = "Runs detekt and generates SARIF report for GitHub Code Scanning"
-    group = "verification"
-
-    buildUponDefaultConfig = true
-    config.setFrom("$projectDir/config/detekt/detekt.yml")
-
-    setSource(files("src/main/kotlin"))
-    include("**/*.kt")
-    exclude("**/test/**", "**/*Test.kt")
-
+// SARIF (for GitHub Code Scanning) is produced by the main `detekt` task
+// itself — a second Detekt task re-analyzing src/main/kotlin just doubled the
+// work in the lint job for the same findings.
+//
+// Note this deliberately WIDENS code-scanning scope: the removed `detektSarif`
+// task carried exclude("**/test/**", "**/*Test.kt"), whereas `detekt` analyses
+// test sources too. That is wanted — the first run under this config caught a
+// real LoopWithTooManyJumpStatements in DslCommentHtmlGuardTest — but it does
+// mean code-scanning alerts can now originate from src/test.
+tasks.named<io.gitlab.arturbosch.detekt.Detekt>("detekt") {
     reports {
+        // Only what something actually consumes: sarif -> GitHub code scanning,
+        // txt -> the PR-summary script, html -> the uploaded artifact humans read.
         sarif.required.set(true)
-        sarif.outputLocation.set(file("build/reports/detekt/detekt.sarif"))
-        html.required.set(false)
         txt.required.set(true)
+        html.required.set(true)
         xml.required.set(false)
     }
-
-    jvmTarget = "21"
-    basePath = projectDir.absolutePath
-    ignoreFailures = true
 }
 
 tasks {
@@ -159,10 +166,12 @@ tasks {
         compilerOptions.jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)
     }
 
-    // Configure Detekt tasks
+    // Configure Detekt tasks. Detekt runs inside the Gradle daemon, so it
+    // depends on gradle/gradle-daemon-jvm.properties pinning that daemon to
+    // Java 21 — on a JDK 26 daemon it aborts with a bare "> 26.0.2".
+    // ignoreFailures is deliberately NOT set: lint gates the build.
     withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
         jvmTarget = "21"
-        ignoreFailures = true  // Don't fail the build on Detekt issues during development
     }
 
     // buildSearchableOptions launches a headless IDE (~23s) purely to index the
@@ -214,6 +223,16 @@ tasks {
     register<Test>("platformTest") {
         description = "Runs IntelliJ Platform tests that need the shared TestApplication."
         group = "verification"
+
+        // Reusing the `test` task's wiring (below) means holding a reference to
+        // that Task, which the configuration cache cannot serialize. Opt this
+        // one task out rather than lose CC everywhere: the common local loops
+        // (`test`, `compileKotlin`, `buildPlugin`) keep it, and only builds that
+        // actually include `platformTest` (e.g. `check`) fall back.
+        // Migrating to intellijPlatformTesting.testIde would restore CC here.
+        notCompatibleWithConfigurationCache(
+            "reuses the `test` task's IntelliJ sandbox wiring, which holds a Task reference"
+        )
 
         // The IntelliJ Platform Gradle plugin only wires its sandbox/module
         // JVM args (IntelliJPlatformArgumentProvider, SandboxArgumentProvider,

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,14 @@
-# Fix Kotlin compiler running on unsupported JDK versions
-# This forces the compiler to run within the Gradle daemon process
+# Runs the Kotlin compiler inside the Gradle daemon instead of forking a
+# separate Kotlin daemon. Originally a workaround for the daemon running on an
+# unsupported JDK; that reason is gone now that gradle/gradle-daemon-jvm.properties
+# pins the daemon to Java 21.
+#
+# Kept anyway, but not because it is faster — it isn't. Warm incremental
+# compile measured ~1.4-1.8s in-process vs ~1.2-1.3s with a Kotlin daemon, so
+# the daemon is consistently a little quicker. The trade is deliberate: staying
+# in-process avoids a second long-lived JVM alongside the Gradle daemon, which
+# matters more on 4-vCPU CI runners than ~0.3s of incremental compile does.
+# Revisit if full (non-incremental) compiles start dominating.
 kotlin.compiler.execution.strategy=in-process
 
 # Plugin metadata
@@ -37,8 +46,16 @@ org.gradle.workers.max = 4
 # File system watching (faster change detection)
 org.gradle.vfs.watch = true
 
-# Configuration cache (disabled - IntelliJ plugin may not fully support)
-org.gradle.configuration-cache = false
+# Configuration cache. The blocker was never the IntelliJ plugin — it was this
+# build capturing the Project inside processResources. `platformTest` is opted
+# out explicitly (see build.gradle.kts); builds including it degrade to a
+# cache-discarded run instead of failing.
+#
+# Scope of the win, stated plainly: koverVerify depends on every Test task,
+# platformTest included, so `test platformTest koverVerify` — i.e. exactly what
+# CI runs — always discards the entry. This pays off in local loops
+# (`./gradlew test`, `compileKotlin`, `buildPlugin`), not in CI.
+org.gradle.configuration-cache = true
 
 # Kotlin incremental compilation
 kotlin.incremental = true

--- a/gradle/gradle-daemon-jvm.properties
+++ b/gradle/gradle-daemon-jvm.properties
@@ -1,0 +1,1 @@
+toolchainVersion=21

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/ui/DslCommentHtmlGuardTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/ui/DslCommentHtmlGuardTest.kt
@@ -21,6 +21,11 @@ class DslCommentHtmlGuardTest {
     private val guardedFunctions = setOf("comment", "rowComment", "text", "contextHelp")
     private val deniedTagPattern = Regex("<(html|body)\\b", RegexOption.IGNORE_CASE)
 
+    /** One guarded call found in a source file: its 1-based line and the raw text between its parens. */
+    private data class CallArgument(val line: Int, val text: String)
+
+    private fun isIdentChar(c: Char) = c.isLetterOrDigit() || c == '_'
+
     @Test
     fun `no literal html or body tag reaches a UI DSL comment-like call`() {
         val root = File("src/main/kotlin")
@@ -41,8 +46,8 @@ class DslCommentHtmlGuardTest {
     private fun findViolations(file: File): List<String> {
         val source = file.readText()
         return findCallArgumentSpans(source, guardedFunctions)
-            .filter { (_, arg) -> deniedTagPattern.containsMatchIn(arg) }
-            .map { (line, _) -> "${file.path}:$line" }
+            .filter { deniedTagPattern.containsMatchIn(it.text) }
+            .map { "${file.path}:${it.line}" }
     }
 
     /**
@@ -102,39 +107,51 @@ class DslCommentHtmlGuardTest {
         return i - 1
     }
 
-    /** Finds every call to a name in [functionNames], returning (1-based line, raw text between its parens). */
-    private fun findCallArgumentSpans(source: String, functionNames: Set<String>): List<Pair<Int, String>> {
-        val results = mutableListOf<Pair<Int, String>>()
+    /** Finds every call to a name in [functionNames]. */
+    private fun findCallArgumentSpans(source: String, functionNames: Set<String>): List<CallArgument> {
+        val results = mutableListOf<CallArgument>()
         val n = source.length
-        fun isIdentChar(c: Char) = c.isLetterOrDigit() || c == '_'
 
+        // Single `i = ...` per iteration (no `continue`s) so the scan stays
+        // easy to follow and each branch's cursor advance is explicit.
         var i = 0
         while (i < n) {
             val skipTo = skipStringOrComment(source, i)
-            if (skipTo != null) {
-                i = skipTo
-                continue
+            val startsIdent = isIdentChar(source[i]) && (i == 0 || !isIdentChar(source[i - 1]))
+            i = when {
+                skipTo != null -> skipTo
+                startsIdent -> appendCallAt(source, i, functionNames, into = results)
+                else -> i + 1
             }
-            val c = source[i]
-            if (isIdentChar(c) && (i == 0 || !isIdentChar(source[i - 1]))) {
-                var j = i
-                while (j < n && isIdentChar(source[j])) j++
-                val ident = source.substring(i, j)
-                var k = j
-                while (k < n && source[k] == ' ') k++
-                if (ident in functionNames && k < n && source[k] == '(') {
-                    val closeIdx = findMatchingClose(source, k)
-                    val arg = source.substring(k + 1, closeIdx.coerceIn(k + 1, n))
-                    val line = 1 + source.substring(0, i).count { it == '\n' }
-                    results.add(line to arg)
-                    i = closeIdx + 1
-                    continue
-                }
-                i = j
-                continue
-            }
-            i++
         }
         return results
+    }
+
+    /**
+     * Reads the identifier starting at [start]. When it names one of
+     * [functionNames] and is followed by a call, appends that call to [into].
+     * Returns the index to resume scanning from either way.
+     */
+    private fun appendCallAt(
+        source: String,
+        start: Int,
+        functionNames: Set<String>,
+        into: MutableList<CallArgument>,
+    ): Int {
+        val n = source.length
+
+        var end = start
+        while (end < n && isIdentChar(source[end])) end++
+        val ident = source.substring(start, end)
+
+        var paren = end
+        while (paren < n && source[paren] == ' ') paren++
+        if (ident !in functionNames || paren >= n || source[paren] != '(') return end
+
+        val closeIdx = findMatchingClose(source, paren)
+        val arg = source.substring(paren + 1, closeIdx.coerceIn(paren + 1, n))
+        val line = 1 + source.substring(0, start).count { it == '\n' }
+        into.add(CallArgument(line, arg))
+        return closeIdx + 1
     }
 }


### PR DESCRIPTION
> Stacked on #27 (which is stacked on #26). Base is `chore/forbid-internal-api`, so this PR's diff shows only its own commit. Review/merge the parents first.

## Summary

Three local-build problems, each traced to a root cause rather than guessed at.

### Configuration cache was blocked by our own build script
It was disabled with a comment blaming the IntelliJ platform plugin. That was wrong — the sole blocker was `processResources` capturing the `Project` inside its action. Fixing it took two attempts: hoisting to a top-level `val` wasn't enough, because in a `.kts` script that becomes a field on the *script object*, so the lambda still captured the script (`cannot serialize Gradle script object references`). Re-binding to a local inside the task block fixes it.

Measured: `processResources` **2s → 0.43s** once the entry is reused. `buildPlugin` is fully CC-compatible.

`platformTest` is opted out explicitly via `notCompatibleWithConfigurationCache` — it reuses the `test` task's IntelliJ sandbox wiring and therefore holds a `Task` reference. Builds including it degrade to a discarded entry rather than failing.

**Scope of the win, stated plainly:** `koverVerify` depends on every `Test` task, `platformTest` included, so the exact command CI runs *always* discards the entry. I tried splitting the CI step to avoid this and verified with `--dry-run` that it doesn't help. **CC pays off locally, not in CI**, and the comment now says so rather than implying otherwise.

### The Gradle daemon ran on JDK 26 while the toolchain is 21
That's why `./gradlew detekt` died with a bare `> 26.0.2` — detekt runs *inside* the daemon and 1.23.8 doesn't support that JDK. `gradle/gradle-daemon-jvm.properties` now pins the daemon to Java 21 by criteria, so any installed JDK 21 is auto-detected with no download repository needed.

### Detekt was decorative; now it gates
With the JVM fixed, `ignoreFailures` is removed so lint actually fails the build, and `detektSarif` is folded into the main `detekt` task's `reports {}` — it was a second task re-analysing `src/main/kotlin` for the same findings. Only the formats something consumes are enabled (sarif → code scanning, txt → PR summary, html → uploaded artifact).

Folding it in **widens code-scanning scope to test sources**, which is deliberate and noted in the build script: it immediately caught a real `LoopWithTooManyJumpStatements` in `DslCommentHtmlGuardTest`, fixed here by extracting `appendCallAt` (one cursor advance per iteration), plus a named `CallArgument` type and a single `isIdentChar`.

## Test plan
- [x] `./gradlew test --configuration-cache` → entry stored, then reused (2s → 0.43s on `processResources`); `buildPlugin` compatible.
- [x] `./gradlew detekt` → runs in ~15s on the pinned JDK 21, **0 findings**, so making it blocking costs nothing today.
- [x] `./gradlew test platformTest koverVerify detekt` → 739 unit + 5 platform tests, 0 failures.
- [x] Verified the html guard still *catches* its bug after the refactor: temporarily reintroducing `<html>` into a `comment()` call turns it red, and green again once reverted. A refactored scanner that silently detected nothing would otherwise have passed.
- [x] Docs corrected to match: `DEVELOPMENT.md` described the daemon pin as living in `gradle.properties`; `TESTING.md`'s inventory omitted the two tests added with the guard.