### PR TITLE
Speed up CI: merge lint into test, pin PR verification to the newest IDE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,16 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  # Test and lint share a job: both need the same warmed Gradle cache and the
+  # same extracted IntelliJ SDK, so running them separately paid that setup
+  # cost twice for no parallelism benefit (detekt takes seconds).
   test:
-    name: Test
+    name: Test & Lint
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      security-events: write
+      actions: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -47,12 +52,37 @@ jobs:
       - name: Test
         run: ./gradlew test platformTest koverVerify --build-cache
 
+      # Detekt gates the build (ignoreFailures was removed), so this failing
+      # fails the job. `detekt` emits the SARIF report itself now.
+      #
+      # `if: always()` so a test failure above does not swallow lint feedback:
+      # without it, detekt would be skipped, no SARIF would exist, and the
+      # upload below would have nothing to publish — which is exactly what
+      # merging the old standalone lint job into this one would otherwise cost.
+      - name: Detekt
+        if: always()
+        run: ./gradlew detekt --build-cache
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: build/reports/tests/
+
+      - name: Upload Detekt SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: build/reports/detekt/detekt.sarif
+          category: detekt
+
+      - name: Upload Detekt reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: detekt-reports
+          path: build/reports/detekt/
 
   verify:
     name: Plugin Verifier
@@ -74,11 +104,55 @@ jobs:
         with:
           cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
 
-      # Catches deprecated / scheduled-for-removal platform API before release
-      # rather than at publish time. failureLevel in build.gradle.kts makes
-      # these actually fail the build instead of only printing a report.
+      # The Plugin Verifier CLI downloads the plugin's Marketplace dependencies
+      # (~1GB, ~2min observed) into ~/.pluginVerifier/loaded-plugins. That is
+      # outside the Gradle user home, so setup-gradle does not cover it.
+      #
+      # The IDEs themselves are deliberately NOT cached: IPGP 2.x resolves them
+      # as Gradle dependencies and extracts each to ~4GB under
+      # ~/.gradle/caches/<version>/transforms/. Three supported lines would blow
+      # GitHub's 10GB per-repo cache budget and evict everything else. Pinning
+      # to one IDE (below) is the lever instead.
+      - name: Cache Plugin Verifier downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.pluginVerifier
+          key: pluginVerifier-${{ runner.os }}-${{ hashFiles('gradle.properties') }}
+          restore-keys: |
+            pluginVerifier-${{ runner.os }}-
+
+      # Deprecations only appear against NEWER IDEs, never the oldest supported
+      # one: the scheduled-for-removal call that forced ADR-0001 carries no
+      # annotation at all in the 2025.3.6 SDK and is only flagged from 262
+      # onward. So PRs verify the NEWEST supported build — pinning the oldest
+      # would silently disable the very gate ADR-0002 exists for.
+      #
+      # Resolved from printProductsReleases, which honours sinceBuild and is the
+      # same source recommended() uses, so nothing is hardcoded here and it
+      # cannot drift from gradle.properties.
+      #
+      # `shell: bash` + pipefail are load-bearing: the default shell for `run:`
+      # is `bash -e` WITHOUT pipefail, so a failing gradle would leave the
+      # pipeline's status coming from `tail`, $IDE empty, and the verification
+      # silently falling back to the full recommended() sweep. The grep is
+      # restricted to the release notation (IU-YYYY.N) because EAP/RC entries
+      # are raw build numbers (IU-263.x), which `sort -V` would rank below
+      # 2025.x and thus mis-pick.
+      - name: Resolve newest supported IDE
+        id: ide
+        shell: bash
+        run: |
+          set -euo pipefail
+          IDE=$(./gradlew printProductsReleases -q | grep -E '^[A-Z]+-[0-9]{4}\.[0-9]+' | sort -V | tail -1)
+          [[ -n "$IDE" ]] || { echo "::error::could not resolve an IDE to verify against"; exit 1; }
+          echo "Newest supported IDE: $IDE"
+          echo "ide=$IDE" >> "$GITHUB_OUTPUT"
+
+      # release.yml still runs the unpinned recommended() sweep over every
+      # supported line. failureLevel in build.gradle.kts makes findings fail the
+      # build rather than only print a report.
       - name: Verify plugin
-        run: ./gradlew verifyPlugin --build-cache
+        run: ./gradlew verifyPlugin -PverifierIdes="${{ steps.ide.outputs.ide }}" --build-cache
 
       - name: Upload verifier report
         if: always()
@@ -87,73 +161,13 @@ jobs:
           name: plugin-verifier-report
           path: build/reports/pluginVerifier/
 
-  lint:
-    name: Lint (Detekt)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-      actions: read
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Java JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
-          cache-read-only: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
-
-      - name: Detekt
-        run: ./gradlew detekt --build-cache
-
-      - name: Detekt SARIF diagnostics
-        if: always()
-        shell: bash
-        continue-on-error: true
-        run: |
-          SARIF_PATH="build/reports/detekt/detekt.sarif"
-          if [[ ! -f "$SARIF_PATH" ]]; then
-            echo "Detekt SARIF diagnostics: file not found at $SARIF_PATH"
-            exit 0
-          fi
-
-          FILE_SIZE=$(wc -c < "$SARIF_PATH" | tr -d ' ')
-          RUNS=$(jq '.runs | length' "$SARIF_PATH" 2>/dev/null || echo 0)
-          RULES=$(jq '[.runs[].tool.driver.rules | length] | add // 0' "$SARIF_PATH" 2>/dev/null || echo 0)
-          RESULTS=$(jq '[.runs[].results | length] | add // 0' "$SARIF_PATH" 2>/dev/null || echo 0)
-
-          echo "Detekt SARIF diagnostics"
-          echo "- file size: ${FILE_SIZE} bytes"
-          echo "- runs: ${RUNS}"
-          echo "- rules: ${RULES}"
-          echo "- total results: ${RESULTS}"
-          echo "Top 20 ruleIds by count:"
-          jq -r '.runs[].results[]?.ruleId? // empty' "$SARIF_PATH" 2>/dev/null \
-            | sort | uniq -c | sort -nr | head -20 || true
-
-      - name: Upload Detekt SARIF
-        uses: github/codeql-action/upload-sarif@v4
-        if: always()
-        with:
-          sarif_file: build/reports/detekt/detekt.sarif
-          category: detekt
-
-      - name: Upload Detekt reports
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: detekt-reports
-          path: build/reports/detekt/
-
   results:
     name: PR results
-    needs: [ test, lint ]
+    # Only `test`, deliberately: this job exists solely to post the detekt
+    # summary comment, and detekt runs there. `verify` is a separate check and
+    # is intended to gate merges via branch protection, which is configured
+    # outside this repo — so it has no reason to block this comment.
+    needs: [ test ]
     if: github.event_name == 'pull_request' && always()
     runs-on: ubuntu-latest
     permissions:
@@ -173,13 +187,22 @@ jobs:
           script: |
             const fs = require('fs');
             try {
-              const detektReport = fs.readFileSync('detekt-reports/detekt.txt', 'utf8');
-              if (detektReport.includes('Build failed with 1 exception')) {
+              // detekt.txt lists one finding per line and is empty when clean.
+              // The previous check looked for a Gradle console string that
+              // never appears in this file, so it never commented at all.
+              const findings = fs.readFileSync('detekt-reports/detekt.txt', 'utf8')
+                .split('\n')
+                .filter(line => line.trim().length > 0);
+              if (findings.length > 0) {
+                const preview = findings.slice(0, 10).join('\n');
                 await github.rest.issues.createComment({
                   issue_number: context.issue.number,
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  body: 'ℹ️ **Detekt found code quality suggestions**\n\nThese are recommendations, not blockers. Check the Detekt reports in the CI artifacts for details.'
+                  body: `❌ **Detekt found ${findings.length} issue(s)** — these block the build.\n\n`
+                    + '```\n' + preview + '\n```\n'
+                    + (findings.length > 10 ? `\n…and ${findings.length - 10} more. ` : '\n')
+                    + 'Full reports are in the CI artifacts, and findings are annotated inline via code scanning.'
                 });
               }
             } catch (error) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Configuration cache is enabled** for local builds — the blocker was this build capturing the
   `Project` inside `processResources`, not the IntelliJ plugin. `platformTest` is opted out, and
   because `koverVerify` depends on every test task, the cache benefits local loops rather than CI.
+- **The Plugin Verifier now runs on pull requests**, against the newest supported IDE — that is
+  where deprecations surface at all, since the oldest supported SDK carries no annotation for
+  them. Releases still sweep every supported line. Lint shares the test job, and the verifier's
+  Marketplace downloads are cached, so the extra check costs little.
 
 ### Fixed
 - Removed all use of platform API that is deprecated or scheduled for removal, so the plugin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -106,13 +106,40 @@ intellijPlatform {
         )
 
         ides {
-            // Opt-in fast local loop: -PverifierLocalIde=/path/to/IDE.app verifies
-            // against an installed IDE instead of downloading the recommended set.
+            // Three ways to pick what to verify against, fastest first:
+            //  -PverifierLocalIde=/path/to/IDE.app  an already-installed IDE
+            //                                       (local loop; no download)
+            //  -PverifierIdes=IU-2025.3.6[,...]     an explicit, pinned set
+            //                                       (PR CI; one IDE is enough
+            //                                       to catch API breakage)
+            //  neither                              recommended(), i.e. every
+            //                                       supported line — thorough
+            //                                       but several GB, so it is
+            //                                       reserved for releases.
             val localIde = project.findProperty("verifierLocalIde") as String?
-            if (localIde != null) {
-                local(localIde)
-            } else {
-                recommended()
+            val verifierIdesProperty = project.findProperty("verifierIdes") as String?
+            val pinnedIdes = verifierIdesProperty
+                ?.split(',')
+                ?.map(String::trim)
+                ?.filter(String::isNotEmpty)
+                .orEmpty()
+
+            // Fail loudly rather than quietly widening scope: if the property
+            // was supplied but yields nothing (empty, blank, or a stray comma),
+            // silently falling through to recommended() would turn a typo into
+            // a multi-GB sweep of every supported line.
+            if (verifierIdesProperty != null && pinnedIdes.isEmpty()) {
+                throw GradleException(
+                    "-PverifierIdes was supplied but resolved to no IDE notations " +
+                        "(got \"$verifierIdesProperty\"). Pass e.g. -PverifierIdes=IU-2026.2.1, " +
+                        "or omit it entirely to verify against recommended()."
+                )
+            }
+
+            when {
+                localIde != null -> local(localIde)
+                pinnedIdes.isNotEmpty() -> ides(pinnedIdes)
+                else -> recommended()
             }
         }
     }


### PR DESCRIPTION
> Stacked on #28 → #27 → #26. Base is `perf/gradle-local-build`, so this PR's diff shows only its own commit. Review/merge the parents first.

## Summary

### One job instead of two
Three jobs each paid a full JDK + Gradle + IntelliJ SDK setup. Detekt takes seconds, so its own job was almost entirely setup cost — fold it into the `test` job, which already has that environment warm. It runs with `if: always()` so a test failure can't swallow lint feedback and leave the SARIF upload with nothing to publish.

### PR verification now pins the *newest* IDE
Verifying every supported line on every PR is several GB. Pinning one IDE is the lever — but it has to be the right one.

**It must be the newest, not the oldest.** I checked the bytecode: the scheduled-for-removal call that forced ADR-0001 carries **no annotation at all** in the 2025.3.6 SDK and is only flagged from 262 onward. Pinning the oldest supported build would have silently disabled the very gate #27 exists for. The oldest is also redundant — we compile against it, so API missing there can't compile in the first place.

The version is resolved from `printProductsReleases`, which honours `sinceBuild` and is the same source `recommended()` uses, so nothing is hardcoded and it can't drift from `gradle.properties`. `release.yml` keeps the unpinned sweep.

That resolution is hardened in two ways it genuinely needs:
- **`shell: bash` + `set -euo pipefail`.** The default `run:` shell is `bash -e` *without* pipefail, so a failing gradle would take its exit status from `tail`, leave `$IDE` empty, and — because an empty value is filtered out — fall straight through to the full `recommended()` sweep on **every PR**. Plus an explicit non-empty guard.
- **The grep is narrowed to the release notation** (`IU-YYYY.N`). EAP/RC entries are raw build numbers (`IU-263.x`), which `sort -V` ranks *below* `2025.x`, so a mixed list would mis-pick.

As defence in depth, `build.gradle.kts` now throws if `-PverifierIdes` is supplied but resolves to nothing, so a typo fails loudly instead of quietly widening scope to a multi-GB sweep.

### Caching what's actually cacheable
`~/.pluginVerifier` is cached instead of `~/.cache/pluginVerifier/ides`. The latter is an IPGP **1.x** path and is empty even on a machine that has run `verifyPlugin`; IPGP 2.x resolves IDEs as Gradle dependencies, while the verifier CLI separately downloads the plugin's Marketplace dependencies (~1GB, ~2min observed) into `~/.pluginVerifier/loaded-plugins`.

The extracted IDEs stay **uncached on purpose**: ~4GB each across three supported lines would blow GitHub's 10GB per-repo budget and evict everything else.

### Also
The PR-comment script tested `detekt.txt` for a Gradle *console* string (`Build failed with 1 exception`) that never appears in that file — so it had never commented once. It now reports real findings and says they block the build, which they do.

## Test plan
- [x] YAML validates; resolve step has `shell: bash`, detekt step has `if: always()`.
- [x] Hardened resolve simulated locally → `IU-2026.2.1` (the newest release line, and the same line where the deprecation is actually flagged).
- [x] **Proved the new guard fires**: `-PverifierIdes=" "` and `-PverifierIdes=","` both fail with an explicit message; a valid `IU-2026.2.1` passes through.
- [x] `./gradlew test platformTest koverVerify detekt` → 739 unit + 5 platform, 0 failures; `verifyPlugin` → `Compatible`.

**Not verifiable locally:** the resolve step running inside CI. Worth confirming on the first run of this PR that the resolved IDE is the newest release line and that `verifyPlugin` consumes it rather than sweeping.