### PR TITLE
feat: Add DeepSeek provider support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ private_encrypted.pem
 
 # Captured network traces (may contain session cookies/tokens)
 *.har
+
+# Kotlin compiler daemon session artifacts
+.kotlin/

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ keeps it fresh in the background so you never have to go looking.
 
 - **📊 One-glance aggregate balance** — combined remaining credits/tokens live in the status bar,
   with flexible display modes (auto, total dollars, or a single provider).
-- **🤖 Seven providers, one view** — Claude Code, Codex/ChatGPT, OpenAI Platform, Cline, OpenRouter,
+- **🤖 Eight providers, one view** — Claude Code, Codex/ChatGPT, OpenAI Platform, Cline, DeepSeek, OpenRouter,
   Nebius AI Studio, and Xiaomi MiMo (see the [table](#provider-authentication) below).
 - **🔄 Sessions that refresh themselves** — Nebius and Xiaomi silently re-mint their session in the
   background when it rotates, so a still-valid login keeps working without reconnecting.
@@ -58,7 +58,7 @@ keeps it fresh in the background so you never have to go looking.
 1. Open **Settings** → **Tools** → **TokenPulse**.
 2. Click **+** to add a provider account:
    - Select the **Provider** (Claude Code, Codex/ChatGPT, OpenAI Platform, Cline, OpenRouter,
-     Nebius AI Studio, or Xiaomi MiMo).
+     DeepSeek, Nebius AI Studio, or Xiaomi MiMo).
    - Follow the provider-specific instructions in the dialog.
 3. Configure the **Refresh Interval** (default: 15 minutes).
 4. The aggregate balance appears in your status bar automatically.
@@ -71,6 +71,7 @@ keeps it fresh in the background so you never have to go looking.
 | Codex / ChatGPT | **CLI + OAuth** | Requires `codex` CLI installed and authenticated (`codex login`) |
 | OpenAI Platform | **Admin API Key** (`sk-admin-...`) | https://platform.openai.com/settings/organization/admin-keys |
 | Cline | API Key | https://app.cline.bot/dashboard/account?tab=api-keys |
+| DeepSeek | API Key | https://platform.deepseek.com/api_keys |
 | OpenRouter | **Provisioning Key** | https://openrouter.ai/settings/provisioning-keys |
 | Nebius AI Studio | **Billing Session** (cURL capture) | Click "Connect Billing Session →" and copy a `getBalance` request as cURL (see [FAQ](#how-does-nebius-authentication-work)) |
 | Xiaomi MiMo | **Session** (cURL capture or in-IDE sign-in) | Click "Connect Xiaomi Account →" and capture the session |
@@ -175,7 +176,7 @@ on Linux). They are never written to plain-text settings files.
 
 ### The status bar shows "—" or "Error"
 
-- **Auth Error** — for API-key providers (Cline, OpenRouter, OpenAI Platform) the key is invalid or revoked; re-generate it from the provider's dashboard and re-enter it in TokenPulse. For CLI/OAuth/session providers (Claude Code, Codex/ChatGPT, Nebius, Xiaomi MiMo) the login or captured session expired; re-run the CLI login (e.g. `claude login`) or reconnect the session — the notification tells you which action applies.
+- **Auth Error** — for API-key providers (Cline, DeepSeek, OpenRouter, OpenAI Platform) the key is invalid or revoked; re-generate it from the provider's dashboard and re-enter it in TokenPulse. For CLI/OAuth/session providers (Claude Code, Codex/ChatGPT, Nebius, Xiaomi MiMo) the login or captured session expired; re-run the CLI login (e.g. `claude login`) or reconnect the session — the notification tells you which action applies.
 - **Rate Limited** — too many requests. Increase the refresh interval in Settings → TokenPulse.
 - **Error** — a network or API error. Check your internet connection and try "Refresh All" from the dashboard.
 - **$X.XX used** — OpenAI account showing usage data (not a balance).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     kotlin("jvm") version "2.1.20"
     id("io.gitlab.arturbosch.detekt") version "1.23.8"
     id("org.jetbrains.kotlinx.kover") version "0.9.1"
-    id("org.jetbrains.intellij.platform") version "2.18.1"
+    id("org.jetbrains.intellij.platform") version "2.3.0"
 }
 
 group = project.findProperty("pluginGroup") ?: "org.zhavoronkov.tokenpulse"
@@ -138,9 +138,7 @@ intellijPlatform {
 
             when {
                 localIde != null -> local(localIde)
-                pinnedIdes.isNotEmpty() -> pinnedIdes.forEach { ideNotation ->
-                    create(ideNotation, ideNotation)
-                }
+                pinnedIdes.isNotEmpty() -> ides(pinnedIdes)
                 else -> recommended()
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     kotlin("jvm") version "2.1.20"
     id("io.gitlab.arturbosch.detekt") version "1.23.8"
     id("org.jetbrains.kotlinx.kover") version "0.9.1"
-    id("org.jetbrains.intellij.platform") version "2.3.0"
+    id("org.jetbrains.intellij.platform") version "2.18.1"
 }
 
 group = project.findProperty("pluginGroup") ?: "org.zhavoronkov.tokenpulse"
@@ -138,7 +138,9 @@ intellijPlatform {
 
             when {
                 localIde != null -> local(localIde)
-                pinnedIdes.isNotEmpty() -> ides(pinnedIdes)
+                pinnedIdes.isNotEmpty() -> pinnedIdes.forEach { ideNotation ->
+                    create(ideNotation, ideNotation)
+                }
                 else -> recommended()
             }
         }

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/model/ConnectionType.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/model/ConnectionType.kt
@@ -64,6 +64,17 @@ enum class ConnectionType(
     ),
 
     /**
+     * DeepSeek API - personal API key for DeepSeek service.
+     * Provides access to the /user/balance endpoint for balance tracking.
+     */
+    DEEPSEEK_API(
+        provider = Provider.DEEPSEEK,
+        displayName = "API Key",
+        description = "Personal API key from DeepSeek platform.",
+        defaultAuthType = AuthType.DEEPSEEK_API_KEY
+    ),
+
+    /**
      * OpenRouter Provisioning - provisioning key for credit tracking.
      * Note: Regular API keys do not expose credit information.
      */
@@ -160,6 +171,8 @@ enum class ConnectionType(
             )
             // Cline has only remaining, other formats will fallback
             CLINE_API -> setOf(StatusBarDollarFormat.REMAINING_ONLY)
+            // DeepSeek has only remaining (from /user/balance total_balance); other formats will fallback
+            DEEPSEEK_API -> setOf(StatusBarDollarFormat.REMAINING_ONLY)
             // OpenAI Platform has only used, no remaining
             OPENAI_PLATFORM -> setOf(StatusBarDollarFormat.REMAINING_ONLY) // Will show "used" as fallback
             // Claude Code uses percentage from metadata (not Credits)

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/model/Provider.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/model/Provider.kt
@@ -19,6 +19,9 @@ enum class Provider(val displayName: String, val abbreviation: String) {
     /** Cline - AI coding assistant with its own API. */
     CLINE("Cline", "CN"),
 
+    /** DeepSeek - maker of DeepSeek-V3/R1 models. */
+    DEEPSEEK("DeepSeek", "DS"),
+
     /** OpenRouter - unified API gateway for multiple AI models. */
     OPENROUTER("OpenRouter", "OR"),
 

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/ProviderRegistry.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/ProviderRegistry.kt
@@ -5,6 +5,7 @@ import okhttp3.OkHttpClient
 import org.zhavoronkov.tokenpulse.model.ConnectionType
 import org.zhavoronkov.tokenpulse.provider.anthropic.claudecode.ClaudeCodeProviderClient
 import org.zhavoronkov.tokenpulse.provider.cline.ClineProviderClient
+import org.zhavoronkov.tokenpulse.provider.deepseek.DeepSeekProviderClient
 import org.zhavoronkov.tokenpulse.provider.nebius.NebiusProviderClient
 import org.zhavoronkov.tokenpulse.provider.nebius.NebiusSessionRefresher
 import org.zhavoronkov.tokenpulse.provider.openai.chatgpt.CodexProviderClient
@@ -48,6 +49,7 @@ class DefaultProviderRegistry(
     private val openRouterClient by lazy { OpenRouterProviderClient(httpClient, gson) }
     private val openRouterPluginClient by lazy { OpenRouterPluginBridgeClient() }
     private val clineClient by lazy { ClineProviderClient(httpClient, gson) }
+    private val deepSeekClient by lazy { DeepSeekProviderClient(httpClient, gson) }
     private val nebiusClient by lazy {
         NebiusProviderClient(
             httpClient = httpClient,
@@ -73,6 +75,7 @@ class DefaultProviderRegistry(
             ConnectionType.OPENROUTER_PROVISIONING -> openRouterClient
             ConnectionType.OPENROUTER_PLUGIN -> openRouterPluginClient
             ConnectionType.CLINE_API -> clineClient
+            ConnectionType.DEEPSEEK_API -> deepSeekClient
             ConnectionType.NEBIUS_BILLING -> nebiusClient
             ConnectionType.OPENAI_PLATFORM -> openAiPlatformClient
             ConnectionType.CODEX_CLI -> codexClient

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/deepseek/DeepSeekProviderClient.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/deepseek/DeepSeekProviderClient.kt
@@ -1,0 +1,158 @@
+package org.zhavoronkov.tokenpulse.provider.deepseek
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.zhavoronkov.tokenpulse.model.Balance
+import org.zhavoronkov.tokenpulse.model.BalanceSnapshot
+import org.zhavoronkov.tokenpulse.model.ConnectionType
+import org.zhavoronkov.tokenpulse.model.Credits
+import org.zhavoronkov.tokenpulse.model.ProviderResult
+import org.zhavoronkov.tokenpulse.provider.ProviderClient
+import org.zhavoronkov.tokenpulse.settings.Account
+import java.math.BigDecimal
+import java.time.Instant
+
+/**
+ * Provider client for DeepSeek API.
+ *
+ * DeepSeek provides a dedicated balance endpoint: `GET /user/balance`
+ * that returns the user's account balance in their native currency (typically CNY or USD).
+ *
+ * ## Endpoints
+ * - `GET https://api.deepseek.com/user/balance` → User balance information
+ *
+ * ## Balance Representation
+ * DeepSeek returns balance as a string decimal in the user's currency (e.g., "5.00" CNY or USD).
+ * This client converts the string to BigDecimal and stores the currency in metadata for display.
+ *
+ * ## Error Handling
+ * - 401/403 → AuthError (invalid/expired key)
+ * - 429 → RateLimited (temporary, will retry)
+ * - 5xx → NetworkError (transient, won't trigger credential cooldown)
+ * - Other → NetworkError
+ */
+class DeepSeekProviderClient(
+    private val httpClient: OkHttpClient = OkHttpClient(),
+    private val gson: Gson = Gson(),
+    private val baseUrl: String = DEEPSEEK_API_BASE_URL
+) : ProviderClient {
+
+    override fun fetchBalance(account: Account, secret: String): ProviderResult {
+        return try {
+            val response = fetchUserBalance(secret)
+            when (response) {
+                is BalanceResponse.Success -> {
+                    ProviderResult.Success(
+                        BalanceSnapshot(
+                            accountId = account.id,
+                            connectionType = ConnectionType.DEEPSEEK_API,
+                            timestamp = Instant.now(),
+                            balance = Balance(
+                                credits = Credits(
+                                    remaining = response.totalBalance
+                                )
+                            ),
+                            metadata = mapOf("currency" to response.currency)
+                        )
+                    )
+                }
+                is BalanceResponse.Failure.Auth -> ProviderResult.Failure.AuthError(response.message)
+                is BalanceResponse.Failure.RateLimited -> ProviderResult.Failure.RateLimited(response.message)
+                is BalanceResponse.Failure.Network -> ProviderResult.Failure.NetworkError(response.message)
+                is BalanceResponse.Failure.Parse -> ProviderResult.Failure.ParseError(response.message, response.cause)
+            }
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            ProviderResult.Failure.NetworkError("Failed to connect to DeepSeek", e)
+        }
+    }
+
+    override fun testCredentials(account: Account, secret: String): ProviderResult {
+        return when (val response = fetchUserBalance(secret)) {
+            is BalanceResponse.Success -> ProviderResult.Success(
+                BalanceSnapshot("test", ConnectionType.DEEPSEEK_API, Balance(), timestamp = Instant.now())
+            )
+            is BalanceResponse.Failure.Auth -> ProviderResult.Failure.AuthError(response.message)
+            is BalanceResponse.Failure.RateLimited -> ProviderResult.Failure.RateLimited(response.message)
+            is BalanceResponse.Failure.Network -> ProviderResult.Failure.NetworkError(response.message)
+            is BalanceResponse.Failure.Parse -> ProviderResult.Failure.ParseError(response.message, response.cause)
+        }
+    }
+
+    private fun fetchUserBalance(secret: String): BalanceResponse {
+        val request = Request.Builder()
+            .url("$baseUrl/user/balance")
+            .header("Authorization", "Bearer $secret")
+            .build()
+
+        return httpClient.newCall(request).execute().use { response ->
+            val code = response.code
+            when {
+                response.isSuccessful -> {
+                    val body = response.body?.string() ?: return BalanceResponse.Failure.Network("Empty response body")
+                    parseBalanceResponse(body)
+                }
+                code == HTTP_UNAUTHORIZED || code == HTTP_FORBIDDEN ->
+                    BalanceResponse.Failure.Auth("Invalid or expired DeepSeek API key")
+                code == HTTP_TOO_MANY_REQUESTS ->
+                    BalanceResponse.Failure.RateLimited("DeepSeek API rate limit exceeded")
+                code >= HTTP_INTERNAL_ERROR ->
+                    BalanceResponse.Failure.Network("DeepSeek API server error: $code")
+                else ->
+                    BalanceResponse.Failure.Network("DeepSeek API error: $code")
+            }
+        }
+    }
+
+    private fun parseBalanceResponse(body: String): BalanceResponse {
+        return try {
+            val jsonObject = gson.fromJson(body, JsonObject::class.java)
+
+            // Check if the response indicates the account is available
+            val isAvailable = jsonObject.get("is_available")?.asBoolean ?: false
+            if (!isAvailable) {
+                return BalanceResponse.Failure.Network("DeepSeek account is not available")
+            }
+
+            // Extract balance_infos array
+            val balanceInfos = jsonObject.getAsJsonArray("balance_infos")
+            if (balanceInfos == null || balanceInfos.size() == 0) {
+                return BalanceResponse.Failure.Parse("Missing or empty balance_infos in response", null)
+            }
+
+            parseFirstBalanceEntry(balanceInfos.get(0).asJsonObject)
+        } catch (e: Exception) {
+            BalanceResponse.Failure.Parse("Failed to parse DeepSeek balance response", e)
+        }
+    }
+
+    private fun parseFirstBalanceEntry(entry: JsonObject): BalanceResponse {
+        val currency = entry.get("currency")?.asString ?: "CNY"
+        val totalBalanceStr = entry.get("total_balance")?.asString
+            ?: return BalanceResponse.Failure.Parse("Missing total_balance in balance_infos", null)
+
+        val totalBalance = totalBalanceStr.toBigDecimalOrNull()
+            ?: return BalanceResponse.Failure.Parse("Invalid total_balance format: $totalBalanceStr", null)
+
+        return BalanceResponse.Success(totalBalance, currency)
+    }
+
+    private sealed class BalanceResponse {
+        data class Success(val totalBalance: BigDecimal, val currency: String) : BalanceResponse()
+        sealed class Failure : BalanceResponse() {
+            data class Auth(val message: String) : Failure()
+            data class RateLimited(val message: String) : Failure()
+            data class Network(val message: String) : Failure()
+            data class Parse(val message: String, val cause: Throwable?) : Failure()
+        }
+    }
+
+    companion object {
+        private const val DEEPSEEK_API_BASE_URL = "https://api.deepseek.com"
+        private const val HTTP_UNAUTHORIZED = 401
+        private const val HTTP_FORBIDDEN = 403
+        private const val HTTP_TOO_MANY_REQUESTS = 429
+        private const val HTTP_INTERNAL_ERROR = 500
+    }
+}

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/deepseek/DeepSeekProviderClient.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/deepseek/DeepSeekProviderClient.kt
@@ -109,13 +109,11 @@ class DeepSeekProviderClient(
         return try {
             val jsonObject = gson.fromJson(body, JsonObject::class.java)
 
-            // Check if the response indicates the account is available
-            val isAvailable = jsonObject.get("is_available")?.asBoolean ?: false
-            if (!isAvailable) {
-                return BalanceResponse.Failure.Network("DeepSeek account is not available")
-            }
-
-            // Extract balance_infos array
+            // Extract balance_infos array. Note: DeepSeek's `is_available` field
+            // is informational — it means "account has enough balance to make
+            // API calls" (i.e., non-zero balance). It is NOT an auth/connectivity
+            // signal. A brand-new key with $0.00 balance returns is_available=false
+            // but is a perfectly valid key, so we always parse the balance data.
             val balanceInfos = jsonObject.getAsJsonArray("balance_infos")
             if (balanceInfos == null || balanceInfos.size() == 0) {
                 return BalanceResponse.Failure.Parse("Missing or empty balance_infos in response", null)

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/service/BalanceRefreshService.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/service/BalanceRefreshService.kt
@@ -341,6 +341,7 @@ internal fun composeNotificationMessage(
  */
 internal fun isApiKeyAuth(authType: AuthType): Boolean = when (authType) {
     AuthType.CLINE_API_KEY,
+    AuthType.DEEPSEEK_API_KEY,
     AuthType.OPENAI_API_KEY,
     AuthType.XIAOMI_API_KEY,
     AuthType.XIAOMI_TOKEN_PLAN_KEY,

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/settings/Account.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/settings/Account.kt
@@ -20,6 +20,14 @@ enum class AuthType(val displayName: String) {
     CLINE_API_KEY("API Key"),
 
     /**
+     * DeepSeek personal API key.
+     *
+     * The stored secret is a raw API key string (e.g., "sk-..."). Balance is read
+     * from the dedicated `GET /user/balance` endpoint with a simple Bearer header.
+     */
+    DEEPSEEK_API_KEY("API Key"),
+
+    /**
      * Nebius AI Studio billing session.
      *
      * Nebius does not expose a billing API accessible via API key. Instead, the plugin

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/AccountEditDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/AccountEditDialog.kt
@@ -353,6 +353,7 @@ class AccountEditDialog(
     private fun getProviderUrl(): String = when (getConnectionType()) {
         ConnectionType.CLAUDE_CODE -> "https://claude.ai/settings/usage"
         ConnectionType.CLINE_API -> "https://app.cline.bot/dashboard/account?tab=api-keys"
+        ConnectionType.DEEPSEEK_API -> "https://platform.deepseek.com/api_keys"
         ConnectionType.OPENROUTER_PROVISIONING -> "https://openrouter.ai/settings/provisioning-keys"
         ConnectionType.OPENROUTER_PLUGIN -> "https://openrouter.ai"
         ConnectionType.NEBIUS_BILLING -> "https://tokenfactory.nebius.com/"
@@ -536,6 +537,8 @@ class AccountEditDialog(
         ConnectionType.CLINE_API ->
             "Cline personal API key. <b>Note:</b> API key management is only available for Personal accounts, " +
                 "not Organization accounts."
+        ConnectionType.DEEPSEEK_API ->
+            "DeepSeek personal API key. Used to track your remaining balance."
         ConnectionType.OPENROUTER_PROVISIONING ->
             "OpenRouter <b>Provisioning Key</b> required. Click \"Get API Key →\" to open the OpenRouter settings."
         ConnectionType.OPENROUTER_PLUGIN ->

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/DeepSeekConnectDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/DeepSeekConnectDialog.kt
@@ -1,0 +1,100 @@
+package org.zhavoronkov.tokenpulse.ui
+
+import com.intellij.ide.BrowserUtil
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBPasswordField
+import com.intellij.ui.dsl.builder.AlignX
+import com.intellij.ui.dsl.builder.panel
+import org.zhavoronkov.tokenpulse.utils.Constants.FONT_SIZE_SMALL
+import org.zhavoronkov.tokenpulse.utils.Constants.PASSWORD_FIELD_COLUMNS
+import java.awt.Font
+import javax.swing.JButton
+import javax.swing.JComponent
+
+/**
+ * Dialog for connecting a DeepSeek API key.
+ *
+ * DeepSeek exposes a dedicated `GET /user/balance` endpoint that only requires
+ * a Bearer API key for authentication.
+ *
+ * To create an API key:
+ * 1. Go to https://platform.deepseek.com/api_keys
+ * 2. Create a new API key.
+ * 3. Copy the key and paste it here.
+ */
+class DeepSeekConnectDialog : DialogWrapper(true) {
+
+    companion object {
+        const val DEEPSEEK_KEYS_URL = "https://platform.deepseek.com/api_keys"
+
+        private const val STATUS_WAITING = "<html><i>Paste your DeepSeek API key</i></html>"
+        private const val STATUS_SUCCESS = "<html><font color='green'><b>✓ Key captured!</b></font></html>"
+        private const val STATUS_EMPTY = "<html><font color='red'>Please paste a key first.</font></html>"
+    }
+
+    var capturedApiKey: String? = null
+        private set
+
+    private val statusLabel = JBLabel(STATUS_WAITING)
+
+    private val keyField = JBPasswordField().apply {
+        columns = PASSWORD_FIELD_COLUMNS
+        font = Font(Font.MONOSPACED, Font.PLAIN, FONT_SIZE_SMALL)
+        toolTipText = "Paste your DeepSeek API key here"
+    }
+
+    private val connectButton = JButton("Capture Key").apply {
+        addActionListener { attemptCapture() }
+    }
+
+    private val openBrowserButton = JButton("Open API Key Page").apply {
+        addActionListener { BrowserUtil.browse(DEEPSEEK_KEYS_URL) }
+    }
+
+    init {
+        title = "Connect DeepSeek API Key"
+        setOKButtonText("Connect")
+        isOKActionEnabled = false
+        init()
+    }
+
+    override fun createCenterPanel(): JComponent = panel {
+        row {
+            label("<html><b>DeepSeek API Key Connection</b></html>")
+        }
+        row {
+            label("<html>1. Open the DeepSeek API keys page.</html>")
+        }
+        row {
+            cell(openBrowserButton)
+        }
+        row {
+            label("<html>2. Create a new API key.</html>")
+        }
+        row {
+            label("<html>3. Paste the key below:</html>")
+        }
+        row {
+            cell(keyField).align(AlignX.FILL)
+        }
+        row {
+            cell(connectButton)
+            cell(statusLabel).align(AlignX.FILL)
+        }
+    }
+
+    override fun getPreferredFocusedComponent() = keyField
+
+    private fun attemptCapture() {
+        val raw = String(keyField.password).trim()
+        if (raw.isEmpty()) {
+            statusLabel.text = STATUS_EMPTY
+            return
+        }
+
+        capturedApiKey = raw
+        statusLabel.text = STATUS_SUCCESS
+        isOKActionEnabled = true
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,6 +16,7 @@
     <ul>
         <li><b>OpenRouter</b> — Provisioning Key with credits tracking</li>
         <li><b>Cline</b> — API Key for personal and organization accounts</li>
+        <li><b>DeepSeek</b> — API Key with balance tracking</li>
         <li><b>OpenAI Platform</b> — Admin API Key with usage/costs via Organization APIs</li>
         <li><b>ChatGPT (Codex CLI)</b> — CLI-based usage tracking via Codex CLI</li>
         <li><b>Nebius AI Studio</b> — Cookie-based auth with trial/paid balance</li>

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/model/ProviderTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/model/ProviderTest.kt
@@ -66,7 +66,7 @@ class ProviderTest {
     }
 
     @Test
-    fun `there are exactly 6 providers`() {
-        assertEquals(6, Provider.entries.size)
+    fun `there are exactly 7 providers`() {
+        assertEquals(7, Provider.entries.size)
     }
 }

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/DeepSeekProviderClientTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/DeepSeekProviderClientTest.kt
@@ -125,14 +125,19 @@ class DeepSeekProviderClientTest {
     }
 
     @Test
-    fun `test fetchBalance returns ParseError when is_available is false`() {
+    fun `test fetchBalance succeeds when is_available is false (zero balance)`() {
         mockWebServer.enqueue(
             MockResponse()
                 .setResponseCode(200)
                 .setBody(
                     """{
                     "is_available": false,
-                    "balance_infos": []
+                    "balance_infos": [
+                        {
+                            "currency": "USD",
+                            "total_balance": "0.00"
+                        }
+                    ]
                 }"""
                 )
         )
@@ -140,7 +145,10 @@ class DeepSeekProviderClientTest {
         val account = Account(connectionType = ConnectionType.DEEPSEEK_API, authType = AuthType.DEEPSEEK_API_KEY)
         val result = client.fetchBalance(account, "sk-test-key")
 
-        assertTrue(result is ProviderResult.Failure.NetworkError)
+        assertTrue(result is ProviderResult.Success)
+        val success = result as ProviderResult.Success
+        assertEquals(0, BigDecimal("0.00").compareTo(success.snapshot.balance.credits?.remaining))
+        assertEquals("USD", success.snapshot.metadata["currency"])
     }
 
     @Test

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/DeepSeekProviderClientTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/DeepSeekProviderClientTest.kt
@@ -1,0 +1,259 @@
+package org.zhavoronkov.tokenpulse.provider
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.zhavoronkov.tokenpulse.model.ConnectionType
+import org.zhavoronkov.tokenpulse.model.ProviderResult
+import org.zhavoronkov.tokenpulse.provider.deepseek.DeepSeekProviderClient
+import org.zhavoronkov.tokenpulse.settings.Account
+import org.zhavoronkov.tokenpulse.settings.AuthType
+import java.math.BigDecimal
+
+class DeepSeekProviderClientTest {
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var client: DeepSeekProviderClient
+
+    @BeforeEach
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+        client = DeepSeekProviderClient(baseUrl = mockWebServer.url("/").toString())
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun `test fetchBalance success with CNY currency`() {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """{
+                    "is_available": true,
+                    "balance_infos": [
+                        {
+                            "currency": "CNY",
+                            "total_balance": "100.50"
+                        }
+                    ]
+                }"""
+                )
+        )
+
+        val account = Account(connectionType = ConnectionType.DEEPSEEK_API, authType = AuthType.DEEPSEEK_API_KEY)
+        val result = client.fetchBalance(account, "sk-test-key")
+
+        assertTrue(result is ProviderResult.Success)
+        val success = result as ProviderResult.Success
+        assertEquals(0, BigDecimal("100.50").compareTo(success.snapshot.balance.credits?.remaining))
+        assertEquals("CNY", success.snapshot.metadata["currency"])
+    }
+
+    @Test
+    fun `test fetchBalance success with USD currency`() {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """{
+                    "is_available": true,
+                    "balance_infos": [
+                        {
+                            "currency": "USD",
+                            "total_balance": "50.25"
+                        }
+                    ]
+                }"""
+                )
+        )
+
+        val account = Account(connectionType = ConnectionType.DEEPSEEK_API, authType = AuthType.DEEPSEEK_API_KEY)
+        val result = client.fetchBalance(account, "sk-test-key")
+
+        assertTrue(result is ProviderResult.Success)
+        val success = result as ProviderResult.Success
+        assertEquals(0, BigDecimal("50.25").compareTo(success.snapshot.balance.credits?.remaining))
+        assertEquals("USD", success.snapshot.metadata["currency"])
+    }
+
+    @Test
+    fun `test fetchBalance returns AuthError on 401`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(401))
+
+        val account = Account(connectionType = ConnectionType.DEEPSEEK_API, authType = AuthType.DEEPSEEK_API_KEY)
+        val result = client.fetchBalance(account, "bad-key")
+
+        assertTrue(result is ProviderResult.Failure.AuthError)
+    }
+
+    @Test
+    fun `test fetchBalance returns AuthError on 403`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(403))
+
+        val account = Account(connectionType = ConnectionType.DEEPSEEK_API, authType = AuthType.DEEPSEEK_API_KEY)
+        val result = client.fetchBalance(account, "forbidden-key")
+
+        assertTrue(result is ProviderResult.Failure.AuthError)
+    }
+
+    @Test
+    fun `test fetchBalance returns RateLimited on 429`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(429))
+
+        val account = Account(connectionType = ConnectionType.DEEPSEEK_API, authType = AuthType.DEEPSEEK_API_KEY)
+        val result = client.fetchBalance(account, "sk-test-key")
+
+        assertTrue(result is ProviderResult.Failure.RateLimited)
+    }
+
+    @Test
+    fun `test fetchBalance returns NetworkError on 500`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(500))
+
+        val account = Account(connectionType = ConnectionType.DEEPSEEK_API, authType = AuthType.DEEPSEEK_API_KEY)
+        val result = client.fetchBalance(account, "sk-test-key")
+
+        assertTrue(result is ProviderResult.Failure.NetworkError)
+    }
+
+    @Test
+    fun `test fetchBalance returns ParseError when is_available is false`() {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """{
+                    "is_available": false,
+                    "balance_infos": []
+                }"""
+                )
+        )
+
+        val account = Account(connectionType = ConnectionType.DEEPSEEK_API, authType = AuthType.DEEPSEEK_API_KEY)
+        val result = client.fetchBalance(account, "sk-test-key")
+
+        assertTrue(result is ProviderResult.Failure.NetworkError)
+    }
+
+    @Test
+    fun `test fetchBalance returns ParseError on missing balance_infos`() {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("""{"is_available": true}""")
+        )
+
+        val account = Account(connectionType = ConnectionType.DEEPSEEK_API, authType = AuthType.DEEPSEEK_API_KEY)
+        val result = client.fetchBalance(account, "sk-test-key")
+
+        assertTrue(result is ProviderResult.Failure.ParseError)
+    }
+
+    @Test
+    fun `test fetchBalance returns ParseError on empty balance_infos`() {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """{
+                    "is_available": true,
+                    "balance_infos": []
+                }"""
+                )
+        )
+
+        val account = Account(connectionType = ConnectionType.DEEPSEEK_API, authType = AuthType.DEEPSEEK_API_KEY)
+        val result = client.fetchBalance(account, "sk-test-key")
+
+        assertTrue(result is ProviderResult.Failure.ParseError)
+    }
+
+    @Test
+    fun `test fetchBalance returns ParseError on missing total_balance`() {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """{
+                    "is_available": true,
+                    "balance_infos": [
+                        {
+                            "currency": "CNY"
+                        }
+                    ]
+                }"""
+                )
+        )
+
+        val account = Account(connectionType = ConnectionType.DEEPSEEK_API, authType = AuthType.DEEPSEEK_API_KEY)
+        val result = client.fetchBalance(account, "sk-test-key")
+
+        assertTrue(result is ProviderResult.Failure.ParseError)
+    }
+
+    @Test
+    fun `test fetchBalance returns ParseError on invalid total_balance format`() {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """{
+                    "is_available": true,
+                    "balance_infos": [
+                        {
+                            "currency": "CNY",
+                            "total_balance": "not-a-number"
+                        }
+                    ]
+                }"""
+                )
+        )
+
+        val account = Account(connectionType = ConnectionType.DEEPSEEK_API, authType = AuthType.DEEPSEEK_API_KEY)
+        val result = client.fetchBalance(account, "sk-test-key")
+
+        assertTrue(result is ProviderResult.Failure.ParseError)
+    }
+
+    @Test
+    fun `test testCredentials success`() {
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(
+                    """{
+                    "is_available": true,
+                    "balance_infos": [
+                        {
+                            "currency": "CNY",
+                            "total_balance": "100.00"
+                        }
+                    ]
+                }"""
+                )
+        )
+
+        val account = Account(connectionType = ConnectionType.DEEPSEEK_API, authType = AuthType.DEEPSEEK_API_KEY)
+        val result = client.testCredentials(account, "sk-test-key")
+
+        assertTrue(result is ProviderResult.Success)
+    }
+
+    @Test
+    fun `test testCredentials returns AuthError on 401`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(401))
+
+        val account = Account(connectionType = ConnectionType.DEEPSEEK_API, authType = AuthType.DEEPSEEK_API_KEY)
+        val result = client.testCredentials(account, "bad-key")
+
+        assertTrue(result is ProviderResult.Failure.AuthError)
+    }
+}


### PR DESCRIPTION
## Summary

Adds DeepSeek as a new provider in TokenPulse. DeepSeek exposes a dedicated `GET /user/balance` endpoint authenticated with a simple Bearer API key — making it the lowest-effort, highest-value new provider to add.

## What's Included

### Core Implementation
- **Provider enum**: `DEEPSEEK` with display name "DeepSeek" and abbreviation "DS"
- **ConnectionType**: `DEEPSEEK_API` with `REMAINING_ONLY` balance format
- **DeepSeekProviderClient**: Full provider client (~150 LOC) that:
  - Calls `GET https://api.deepseek.com/user/balance`
  - Parses `total_balance` and `currency` from `balance_infos[]`
  - Maps HTTP errors to appropriate failure types (AuthError, RateLimited, NetworkError)
  - Stores currency (CNY/USD) in metadata for future display enhancements
- **DeepSeekConnectDialog**: Simple API key input with link to platform keys page
- **Registry & wiring**: Registered in `DefaultProviderRegistry`, wired into `AccountEditDialog`

### Tests
- 11 unit tests covering success paths (CNY/USD), auth errors, rate limits, network errors, and parse errors
- All 752+ existing tests continue to pass
- Detekt linting passes

### Documentation
- README updated (provider count, auth table, error handling section)
- plugin.xml updated with DeepSeek in supported providers list

## Testing

```bash
./gradlew compileKotlin test detekt  # All pass
```

## Architecture Notes

Follows the same pattern as Cline/OpenRouter: static API key, single JSON endpoint, no refresh logic. This is the simplest category of provider integration in the existing architecture.