### PR TITLE
feat: add GitHub Copilot provider (personal + org budget)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Removed all use of platform API that is deprecated or scheduled for removal, so the plugin
   verifies cleanly against current IDEs.
+- **Add/Edit Account dialog hint no longer floods the log or gets stuck tall** — the provider
+  hint text was double-wrapped in `<html>`, which threw a SEVERE `UiDslException` on every
+  connection-type change under the 2025.3 SDK (the DSL `comment()` label inserts `<html>`
+  itself). The manual wrapper is removed, and the dialog now re-packs after the hint changes so
+  it shrinks back to fit shorter hints instead of staying at its tallest size.
 
 ### Removed
 - Individual TokenPulse settings are no longer indexed for Settings search

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     kotlin("jvm") version "2.1.20"
     id("io.gitlab.arturbosch.detekt") version "1.23.8"
     id("org.jetbrains.kotlinx.kover") version "0.9.1"
-    id("org.jetbrains.intellij.platform") version "2.3.0"
+    id("org.jetbrains.intellij.platform") version "2.18.1"
 }
 
 group = project.findProperty("pluginGroup") ?: "org.zhavoronkov.tokenpulse"
@@ -48,7 +48,17 @@ dependencies {
     // `platformTest` actually discovers and runs TokenPulseSmokeTest.
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.11.4")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0") {
+        // Exclude the transitive kotlinx-coroutines-core-jvm — IntelliJ's
+        // bundled lib/util-8.jar ships a patched version (1.10.1-intellij-5)
+        // that includes `runBlockingWithParallelismCompensation`. If the plain
+        // 1.9.0 core JAR lands on the classpath, the PathClassLoader resolves
+        // `kotlinx.coroutines.BuildersKt` from it (missing the method) before
+        // reaching util-8.jar, causing NoSuchMethodError during tearDown.
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core-jvm")
+        exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-bom")
+    }
     // pty4j is provided by IntelliJ platform at runtime - no explicit dependency needed
 
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.8")
@@ -138,7 +148,12 @@ intellijPlatform {
 
             when {
                 localIde != null -> local(localIde)
-                pinnedIdes.isNotEmpty() -> ides(pinnedIdes)
+                // IntelliJ Platform Gradle Plugin 2.18.1 removed the
+                // `ides(List<String>)` overload. Explicit, pinned notations
+                // (e.g. IU-2025.3.6) now go through `create(Provider<List<String>>)`,
+                // whose default configure block parses each notation into a
+                // (type, version) installer dependency.
+                pinnedIdes.isNotEmpty() -> create(providers.provider { pinnedIdes })
                 else -> recommended()
             }
         }
@@ -203,15 +218,10 @@ tasks {
 
     // buildSearchableOptions launches a headless IDE (~23s) purely to index the
     // plugin's settings so individual options are findable in Settings search.
-    // Disabled outright: on the 2025.3.6 SDK its bundled JBR aborts at JVM
-    // startup on macOS (SIGABRT in Threads::create_vm -> post_vm_initialized,
-    // ~0.18s in, before any plugin code runs), so it breaks local release
-    // builds and buys little — the TokenPulse settings PAGE is still reachable
-    // from Settings search either way, only the individual option labels are
-    // not indexed.
-    named("buildSearchableOptions") {
-        enabled = false
-    }
+    // Re-enabled after upgrading IntelliJ Platform Gradle Plugin 2.3.0 → 2.18.1.
+    // The plugin 2.3.0 generated a broken coroutines javaagent JAR that caused
+    // SIGABRT at JVM startup on macOS aarch64 with JBR 21.0.11 and IDE 2025.3.6.
+    // Plugin 2.18.1 fixes the agent generation, so buildSearchableOptions now works.
 
     // Configure tests
     test {
@@ -246,55 +256,6 @@ tasks {
         }
     }
 
-    // Serial task for IntelliJ Platform tests that need the shared TestApplication.
-    register<Test>("platformTest") {
-        description = "Runs IntelliJ Platform tests that need the shared TestApplication."
-        group = "verification"
-
-        // Reusing the `test` task's wiring (below) means holding a reference to
-        // that Task, which the configuration cache cannot serialize. Opt this
-        // one task out rather than lose CC everywhere: the common local loops
-        // (`test`, `compileKotlin`, `buildPlugin`) keep it, and only builds that
-        // actually include `platformTest` (e.g. `check`) fall back.
-        // Migrating to intellijPlatformTesting.testIde would restore CC here.
-        notCompatibleWithConfigurationCache(
-            "reuses the `test` task's IntelliJ sandbox wiring, which holds a Task reference"
-        )
-
-        // The IntelliJ Platform Gradle plugin only wires its sandbox/module
-        // JVM args (IntelliJPlatformArgumentProvider, SandboxArgumentProvider,
-        // the rearranged plugin/IDE classpath, a custom javaLauncher) onto the
-        // task literally named "test". A separately `register<Test>(...)`
-        // task does NOT get that configuration automatically — without it,
-        // BasePlatformTestCase fails to bootstrap the IDE test application
-        // (IllegalAccessError in UITestUtil). So reuse the already fully
-        // configured "test" task's classpath/args/launcher here and just
-        // retarget which tests run via `filter`.
-        val testTask = named<Test>("test").get()
-        // The reused jvmArgumentProviders/classpath resolve sandbox output
-        // (prepareTestSandbox) at execution time without Gradle seeing it as
-        // a task input, so the sandbox-prep dependency must be declared
-        // explicitly here too.
-        dependsOn("prepareTestSandbox")
-        testClassesDirs = testTask.testClassesDirs
-        classpath = testTask.classpath
-        jvmArgumentProviders.addAll(testTask.jvmArgumentProviders)
-        systemProperties = testTask.systemProperties
-        javaLauncher.set(testTask.javaLauncher)
-
-        useJUnitPlatform()
-        filter {
-            includeTestsMatching("org.zhavoronkov.tokenpulse.TokenPulseSmokeTest")
-        }
-        systemProperty("tokenpulse.testMode", "true")
-        maxParallelForks = 1
-
-        reports {
-            junitXml.required.set(true)
-            html.required.set(true)
-        }
-    }
-
     // Separate task to run only functional tests
     register<Test>("functionalTest") {
         description = "Runs functional/integration tests that require external dependencies"
@@ -315,6 +276,51 @@ tasks {
     // Ensure the platform smoke test still runs as part of `check` / `build`.
     named("check") {
         dependsOn("platformTest")
+    }
+}
+
+// Serial task for IntelliJ Platform tests that need the shared TestApplication.
+//
+// Uses the official `intellijPlatformTesting.testIde { ... }` API from the
+// IntelliJ Platform Gradle plugin (2.18.1). This registers a `TestIdeTask` —
+// a Gradle `Test` subtype the plugin fully wires with:
+//   • the 9-step classpath order that puts `intellijPlatformClasspathConfiguration`
+//     (bundled `lib/util-8.jar`, which carries IntelliJ's patched coroutines
+//     with `runBlockingWithParallelismCompensation`) BEFORE the resolved
+//     testRuntimeClasspath — so the plain `kotlinx-coroutines-core-jvm:1.9.0`
+//     (transitive of `kotlinx-coroutines-test`) can't shadow IntelliJ's
+//     patched `BuildersKt`
+//   • `intelliJPlatformTestRuntimeFixClasspathConfiguration`
+//     (see YouTrack IJPL-180516)
+//   • sandbox directories, IDE home path, `coroutines-javaagent.jar`
+//   • the IntelliJ Java launcher
+// Handrolling this with `register<Test>("platformTest")` (previous approach)
+// missed the classpath-fix step, which surfaced as
+//   NoSuchMethodError: kotlinx.coroutines.BuildersKt.runBlockingWithParallelismCompensation
+// during `BasePlatformTestCase.tearDown()`.
+//
+// Bonus: `TestIdeTask` is configuration-cache compatible, so the previous
+// `notCompatibleWithConfigurationCache(...)` opt-out is no longer needed.
+intellijPlatformTesting {
+    testIde {
+        register("platformTest") {
+            task {
+                description = "Runs IntelliJ Platform tests that need the shared TestApplication."
+                group = "verification"
+
+                useJUnitPlatform()
+                filter {
+                    includeTestsMatching("org.zhavoronkov.tokenpulse.TokenPulseSmokeTest")
+                }
+                systemProperty("tokenpulse.testMode", "true")
+                maxParallelForks = 1
+
+                reports {
+                    junitXml.required.set(true)
+                    html.required.set(true)
+                }
+            }
+        }
     }
 }
 

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/model/ConnectionType.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/model/ConnectionType.kt
@@ -142,6 +142,34 @@ enum class ConnectionType(
         displayName = "Token Plan",
         description = "Token Plan subscription with Credits quota. Tracked via Xiaomi platform session.",
         defaultAuthType = AuthType.XIAOMI_TOKEN_PLAN_KEY
+    ),
+
+    /**
+     * GitHub Copilot personal billing - per-user usage via Personal Access Token.
+     *
+     * Reports premium-request spend (headline) and AI-credit spend (metadata).
+     * These endpoints return usage/spend, not a remaining balance, so this
+     * connection type shows a "used" figure (like [OPENAI_PLATFORM]).
+     */
+    GITHUB_COPILOT_PAT(
+        provider = Provider.GITHUB,
+        displayName = "Personal (PAT)",
+        description = "Per-user Copilot spend via a Personal Access Token with billing read permission.",
+        defaultAuthType = AuthType.GITHUB_COPILOT_PAT
+    ),
+
+    /**
+     * GitHub Copilot org billing - budget tracking via an org admin PAT.
+     *
+     * Reports budget_amount (total) and consumed_amount (used) for Copilot
+     * budgets, yielding a true remaining figure. Requires org admin /
+     * billing-manager authorization.
+     */
+    GITHUB_COPILOT_ORG_BUDGET(
+        provider = Provider.GITHUB,
+        displayName = "Organization (Budget)",
+        description = "Copilot org budget tracking. Requires an org admin/billing-manager PAT.",
+        defaultAuthType = AuthType.GITHUB_COPILOT_ORG_BUDGET_PAT
     );
 
     /**
@@ -195,6 +223,14 @@ enum class ConnectionType(
             )
             // Legacy Xiaomi Token Plan uses Credits (percentage-based)
             XIAOMI_TOKEN_PLAN -> emptySet() // Uses Credits percentage, not dollar formats
+            // GitHub Copilot personal (PAT) has only used, no remaining (usage endpoint)
+            GITHUB_COPILOT_PAT -> setOf(StatusBarDollarFormat.REMAINING_ONLY) // Will show "used" as fallback
+            // GitHub Copilot org (budget) has remaining + used, supports all formats
+            GITHUB_COPILOT_ORG_BUDGET -> setOf(
+                StatusBarDollarFormat.REMAINING_ONLY,
+                StatusBarDollarFormat.USED_OF_REMAINING,
+                StatusBarDollarFormat.PERCENTAGE_REMAINING
+            )
         }
 
     /**

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/model/Provider.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/model/Provider.kt
@@ -29,7 +29,10 @@ enum class Provider(val displayName: String, val abbreviation: String) {
     NEBIUS("Nebius", "NB"),
 
     /** Xiaomi - MiMo AI platform (pay-as-you-go and Token Plan). */
-    XIAOMI("Xiaomi", "XM");
+    XIAOMI("Xiaomi", "XM"),
+
+    /** GitHub - Copilot billing (per-user usage and org budgets). */
+    GITHUB("GitHub Copilot", "GH");
 
     companion object {
         /**

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/ProviderRegistry.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/ProviderRegistry.kt
@@ -6,6 +6,8 @@ import org.zhavoronkov.tokenpulse.model.ConnectionType
 import org.zhavoronkov.tokenpulse.provider.anthropic.claudecode.ClaudeCodeProviderClient
 import org.zhavoronkov.tokenpulse.provider.cline.ClineProviderClient
 import org.zhavoronkov.tokenpulse.provider.deepseek.DeepSeekProviderClient
+import org.zhavoronkov.tokenpulse.provider.github.GitHubCopilotBudgetProviderClient
+import org.zhavoronkov.tokenpulse.provider.github.GitHubCopilotProviderClient
 import org.zhavoronkov.tokenpulse.provider.nebius.NebiusProviderClient
 import org.zhavoronkov.tokenpulse.provider.nebius.NebiusSessionRefresher
 import org.zhavoronkov.tokenpulse.provider.openai.chatgpt.CodexProviderClient
@@ -69,6 +71,8 @@ class DefaultProviderRegistry(
             sessionWriter = sessionWriter
         )
     }
+    private val gitHubCopilotClient by lazy { GitHubCopilotProviderClient(httpClient, gson) }
+    private val gitHubCopilotBudgetClient by lazy { GitHubCopilotBudgetProviderClient(httpClient, gson) }
 
     override fun getClient(connectionType: ConnectionType): ProviderClient {
         return when (connectionType) {
@@ -83,6 +87,8 @@ class DefaultProviderRegistry(
             ConnectionType.XIAOMI,
             ConnectionType.XIAOMI_API,
             ConnectionType.XIAOMI_TOKEN_PLAN -> xiaomiClient
+            ConnectionType.GITHUB_COPILOT_PAT -> gitHubCopilotClient
+            ConnectionType.GITHUB_COPILOT_ORG_BUDGET -> gitHubCopilotBudgetClient
         }
     }
 }

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/github/GitHubCopilotBudgetProviderClient.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/github/GitHubCopilotBudgetProviderClient.kt
@@ -1,0 +1,244 @@
+package org.zhavoronkov.tokenpulse.provider.github
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.zhavoronkov.tokenpulse.model.Balance
+import org.zhavoronkov.tokenpulse.model.BalanceSnapshot
+import org.zhavoronkov.tokenpulse.model.ConnectionType
+import org.zhavoronkov.tokenpulse.model.Credits
+import org.zhavoronkov.tokenpulse.model.ProviderResult
+import org.zhavoronkov.tokenpulse.provider.ProviderClient
+import org.zhavoronkov.tokenpulse.settings.Account
+import java.math.BigDecimal
+import java.time.Instant
+
+/**
+ * Provider client for GitHub Copilot **organization** billing (budgets).
+ *
+ * ## Endpoint
+ * - `GET https://api.github.com/organizations/{org}/settings/billing/budgets`
+ *
+ * ## Auth
+ * Personal Access Token belonging to an org admin / billing manager. Sent as
+ * `Authorization: Bearer <pat>`.
+ *
+ * ## Balance Representation
+ * Unlike the per-user usage endpoints, org budgets carry both a limit
+ * (`budget_amount`) and consumption (`consumed_amount`), so this client can
+ * report a real remaining figure. It sums the Copilot-relevant budgets
+ * (`ai_credits`, `premium_requests`) and computes
+ * `remaining = total - used`.
+ *
+ * ## Error Handling
+ * Mirrors [GitHubCopilotProviderClient]: 401/403 → AuthError, 429 → RateLimited,
+ * 5xx → NetworkError, parse failures → ParseError.
+ */
+class GitHubCopilotBudgetProviderClient(
+    private val httpClient: OkHttpClient = OkHttpClient(),
+    private val gson: Gson = Gson(),
+    private val baseUrl: String = GitHubCopilotProviderClient.GITHUB_API_BASE_URL
+) : ProviderClient {
+
+    override fun fetchBalance(account: Account, secret: String): ProviderResult {
+        val parsed = GitHubSecrets.parseOrgBudget(secret)
+            ?: return ProviderResult.Failure.AuthError(
+                "GitHub Copilot org secret is missing or malformed. Reconnect the account."
+            )
+        return try {
+            when (val response = fetchBudgets(parsed)) {
+                is BudgetResponse.Success -> ProviderResult.Success(
+                    BalanceSnapshot(
+                        accountId = account.id,
+                        connectionType = ConnectionType.GITHUB_COPILOT_ORG_BUDGET,
+                        balance = Balance(
+                            credits = Credits(
+                                total = response.totalBudget,
+                                used = response.totalConsumed,
+                                remaining = response.totalBudget.subtract(response.totalConsumed)
+                            )
+                        ),
+                        timestamp = Instant.now(),
+                        metadata = mapOf(
+                            "currency" to "USD",
+                            "org" to parsed.org,
+                            "budgetCount" to response.budgetCount.toString(),
+                            "skus" to response.skus.joinToString(",")
+                        )
+                    )
+                )
+                is BudgetResponse.Failure -> response.toFailure()
+            }
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            ProviderResult.Failure.NetworkError("Failed to connect to GitHub", e)
+        }
+    }
+
+    override fun testCredentials(account: Account, secret: String): ProviderResult {
+        val parsed = GitHubSecrets.parseOrgBudget(secret)
+            ?: return ProviderResult.Failure.AuthError("GitHub Copilot org secret is missing or malformed.")
+        return when (val response = fetchBudgets(parsed)) {
+            is BudgetResponse.Success -> ProviderResult.Success(
+                BalanceSnapshot(
+                    accountId = "test",
+                    connectionType = ConnectionType.GITHUB_COPILOT_ORG_BUDGET,
+                    balance = Balance(),
+                    timestamp = Instant.now()
+                )
+            )
+            is BudgetResponse.Failure -> response.toFailure()
+        }
+    }
+
+    private fun fetchBudgets(secret: GitHubOrgBudgetSecret): BudgetResponse {
+        var totalBudget = BigDecimal.ZERO
+        var totalConsumed = BigDecimal.ZERO
+        var budgetCount = 0
+        val skus = linkedSetOf<String>()
+        var url: String? =
+            "$baseUrl/organizations/${secret.org}/settings/billing/budgets?per_page=$PER_PAGE"
+
+        while (url != null) {
+            val request = Request.Builder()
+                .url(url)
+                .header("Authorization", "Bearer ${secret.pat}")
+                .header("Accept", GitHubCopilotProviderClient.GITHUB_ACCEPT)
+                .header("X-GitHub-Api-Version", GitHubCopilotProviderClient.GITHUB_API_VERSION)
+                .build()
+
+            val pageResult = httpClient.newCall(request).execute().use { response ->
+                val code = response.code
+                when {
+                    response.isSuccessful -> parsePage(response)
+                    code == HTTP_UNAUTHORIZED || code == HTTP_FORBIDDEN ->
+                        PageResult.Fail(
+                            BudgetResponse.Failure.Auth(
+                                "GitHub rejected the PAT (HTTP $code). An org admin/billing-manager " +
+                                    "token is required for budget access."
+                            )
+                        )
+                    code == HTTP_TOO_MANY_REQUESTS ->
+                        PageResult.Fail(BudgetResponse.Failure.RateLimited(rateLimitMessage(response)))
+                    code >= HTTP_INTERNAL_ERROR ->
+                        PageResult.Fail(BudgetResponse.Failure.Network("GitHub API server error: $code"))
+                    else ->
+                        PageResult.Fail(BudgetResponse.Failure.Network("GitHub API error: $code"))
+                }
+            }
+
+            when (pageResult) {
+                is PageResult.Fail -> return pageResult.failure
+                is PageResult.Ok -> {
+                    totalBudget = totalBudget.add(pageResult.budget)
+                    totalConsumed = totalConsumed.add(pageResult.consumed)
+                    budgetCount += pageResult.count
+                    skus.addAll(pageResult.skus)
+                    url = pageResult.nextUrl
+                }
+            }
+        }
+
+        return BudgetResponse.Success(totalBudget, totalConsumed, budgetCount, skus.toList())
+    }
+
+    private fun parsePage(response: Response): PageResult {
+        val body = response.body?.string()
+            ?: return PageResult.Fail(BudgetResponse.Failure.Network("Empty response body"))
+        return try {
+            val json = gson.fromJson(body, JsonObject::class.java)
+                ?: return PageResult.Fail(BudgetResponse.Failure.Parse("GitHub returned empty JSON", null))
+            val budgets = json.getAsJsonArray("budgets")
+            var budget = BigDecimal.ZERO
+            var consumed = BigDecimal.ZERO
+            var count = 0
+            val skus = linkedSetOf<String>()
+            budgets?.forEach { element ->
+                if (!element.isJsonObject) return@forEach
+                val item = element.asJsonObject
+                val sku = item.get("budget_product_sku")?.takeIf { it.isJsonPrimitive }?.asString
+                if (sku != null && sku !in COPILOT_SKUS) return@forEach
+                budget = budget.add(item.bigDecimal("budget_amount"))
+                consumed = consumed.add(item.bigDecimal("consumed_amount"))
+                if (sku != null) skus.add(sku)
+                count += 1
+            }
+            val nextUrl = nextPageUrl(response)
+            PageResult.Ok(budget, consumed, count, skus, nextUrl)
+        } catch (e: Exception) {
+            PageResult.Fail(BudgetResponse.Failure.Parse("Failed to parse GitHub budgets response", e))
+        }
+    }
+
+    /**
+     * Extracts the `rel="next"` URL from the RFC 5988 `Link` header GitHub
+     * uses for pagination. Returns null when there is no next page.
+     */
+    private fun nextPageUrl(response: Response): String? {
+        val link = response.header("Link") ?: return null
+        return link.split(",").firstNotNullOfOrNull { part ->
+            val segments = part.split(";")
+            if (segments.size < 2) return@firstNotNullOfOrNull null
+            val rel = segments.drop(1).any { it.trim() == "rel=\"next\"" }
+            if (!rel) return@firstNotNullOfOrNull null
+            segments.first().trim().removePrefix("<").removeSuffix(">").takeIf { it.isNotEmpty() }
+        }
+    }
+
+    private fun rateLimitMessage(response: Response): String {
+        val retryAfter = response.header("Retry-After")?.trim()
+        return if (!retryAfter.isNullOrEmpty()) {
+            "GitHub API rate limit exceeded. Retry after ${retryAfter}s."
+        } else {
+            "GitHub API rate limit exceeded"
+        }
+    }
+
+    private fun JsonObject.bigDecimal(key: String): BigDecimal =
+        get(key)?.takeIf { it.isJsonPrimitive }?.asBigDecimal ?: BigDecimal.ZERO
+
+    private sealed class PageResult {
+        data class Ok(
+            val budget: BigDecimal,
+            val consumed: BigDecimal,
+            val count: Int,
+            val skus: Set<String>,
+            val nextUrl: String?
+        ) : PageResult()
+        data class Fail(val failure: BudgetResponse.Failure) : PageResult()
+    }
+
+    private sealed class BudgetResponse {
+        data class Success(
+            val totalBudget: BigDecimal,
+            val totalConsumed: BigDecimal,
+            val budgetCount: Int,
+            val skus: List<String>
+        ) : BudgetResponse()
+        sealed class Failure : BudgetResponse() {
+            abstract fun toFailure(): ProviderResult.Failure
+            data class Auth(val message: String) : Failure() {
+                override fun toFailure() = ProviderResult.Failure.AuthError(message)
+            }
+            data class RateLimited(val message: String) : Failure() {
+                override fun toFailure() = ProviderResult.Failure.RateLimited(message)
+            }
+            data class Network(val message: String) : Failure() {
+                override fun toFailure() = ProviderResult.Failure.NetworkError(message)
+            }
+            data class Parse(val message: String, val cause: Throwable?) : Failure() {
+                override fun toFailure() = ProviderResult.Failure.ParseError(message, cause)
+            }
+        }
+    }
+
+    companion object {
+        private const val PER_PAGE = 100
+        private const val HTTP_UNAUTHORIZED = 401
+        private const val HTTP_FORBIDDEN = 403
+        private const val HTTP_TOO_MANY_REQUESTS = 429
+        private const val HTTP_INTERNAL_ERROR = 500
+        private val COPILOT_SKUS = setOf("ai_credits", "premium_requests")
+    }
+}

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/github/GitHubCopilotProviderClient.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/github/GitHubCopilotProviderClient.kt
@@ -1,0 +1,217 @@
+package org.zhavoronkov.tokenpulse.provider.github
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.zhavoronkov.tokenpulse.model.Balance
+import org.zhavoronkov.tokenpulse.model.BalanceSnapshot
+import org.zhavoronkov.tokenpulse.model.ConnectionType
+import org.zhavoronkov.tokenpulse.model.Credits
+import org.zhavoronkov.tokenpulse.model.ProviderResult
+import org.zhavoronkov.tokenpulse.provider.ProviderClient
+import org.zhavoronkov.tokenpulse.settings.Account
+import java.math.BigDecimal
+import java.time.Instant
+import java.time.YearMonth
+
+/**
+ * Provider client for GitHub Copilot **personal** billing (per-user).
+ *
+ * ## Endpoints
+ * - `GET https://api.github.com/users/{username}/settings/billing/premium_request/usage`
+ * - `GET https://api.github.com/users/{username}/settings/billing/ai_credit/usage`
+ *
+ * ## Auth
+ * Personal Access Token with billing read permission. Sent as:
+ * `Authorization: Bearer <pat>`
+ *
+ * ## Balance Representation
+ * GitHub's per-user endpoints report **spend/usage**, not a remaining balance
+ * (only org-scoped Budgets carry `budget_amount`). The headline metric is
+ * premium_request net spend for the current period; AI-credit net spend is
+ * exposed via metadata for the tooltip.
+ *
+ * ## Error Handling
+ * - 401/403 → AuthError (invalid PAT or missing scope)
+ * - 429     → RateLimited (includes any `Retry-After` seconds when present)
+ * - 5xx     → NetworkError
+ * - other   → NetworkError
+ */
+class GitHubCopilotProviderClient(
+    private val httpClient: OkHttpClient = OkHttpClient(),
+    private val gson: Gson = Gson(),
+    private val baseUrl: String = GITHUB_API_BASE_URL
+) : ProviderClient {
+
+    override fun fetchBalance(account: Account, secret: String): ProviderResult {
+        val parsed = GitHubSecrets.parseCopilot(secret)
+            ?: return ProviderResult.Failure.AuthError(
+                "GitHub Copilot secret is missing or malformed. Reconnect the account."
+            )
+        return try {
+            val premium = fetchUsage(parsed, PRODUCT_PREMIUM_REQUEST)
+            if (premium is UsageResponse.Failure) return premium.toFailure()
+            val aiCredit = fetchUsage(parsed, PRODUCT_AI_CREDIT)
+            // AI-credit failure is not fatal: the headline is premium_request.
+            // If it fails we still return the primary snapshot but omit the
+            // ai-credit metadata so the tooltip shows "n/a" rather than a lie.
+            val premiumSuccess = premium as UsageResponse.Success
+            val aiCreditSuccess = (aiCredit as? UsageResponse.Success)
+
+            val metadata = buildMetadata(premiumSuccess, aiCreditSuccess, parsed)
+
+            ProviderResult.Success(
+                BalanceSnapshot(
+                    accountId = account.id,
+                    connectionType = ConnectionType.GITHUB_COPILOT_PAT,
+                    balance = Balance(
+                        credits = Credits(used = premiumSuccess.netAmount)
+                    ),
+                    timestamp = Instant.now(),
+                    metadata = metadata
+                )
+            )
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            ProviderResult.Failure.NetworkError("Failed to connect to GitHub", e)
+        }
+    }
+
+    override fun testCredentials(account: Account, secret: String): ProviderResult {
+        val parsed = GitHubSecrets.parseCopilot(secret)
+            ?: return ProviderResult.Failure.AuthError(
+                "GitHub Copilot secret is missing or malformed."
+            )
+        return when (val response = fetchUsage(parsed, PRODUCT_PREMIUM_REQUEST)) {
+            is UsageResponse.Success -> ProviderResult.Success(
+                BalanceSnapshot(
+                    accountId = "test",
+                    connectionType = ConnectionType.GITHUB_COPILOT_PAT,
+                    balance = Balance(),
+                    timestamp = Instant.now()
+                )
+            )
+            is UsageResponse.Failure -> response.toFailure()
+        }
+    }
+
+    private fun buildMetadata(
+        premium: UsageResponse.Success,
+        aiCredit: UsageResponse.Success?,
+        parsed: GitHubCopilotSecret
+    ): Map<String, String> {
+        val period = YearMonth.now().toString()
+        val base = mapOf(
+            "currency" to "USD",
+            "period" to period,
+            "username" to parsed.username,
+            "premiumRequestsUsed" to premium.netAmount.toPlainString(),
+            "premiumRequestItems" to premium.itemCount.toString()
+        )
+        return if (aiCredit != null) {
+            base + mapOf(
+                "aiCreditsUsed" to aiCredit.netAmount.toPlainString(),
+                "aiCreditItems" to aiCredit.itemCount.toString()
+            )
+        } else {
+            base + mapOf("aiCreditsUsed" to "unavailable")
+        }
+    }
+
+    private fun fetchUsage(secret: GitHubCopilotSecret, product: String): UsageResponse {
+        val url = "$baseUrl/users/${secret.username}/settings/billing/$product/usage"
+        val request = Request.Builder()
+            .url(url)
+            .header("Authorization", "Bearer ${secret.pat}")
+            .header("Accept", GITHUB_ACCEPT)
+            .header("X-GitHub-Api-Version", GITHUB_API_VERSION)
+            .build()
+
+        return httpClient.newCall(request).execute().use { response ->
+            val code = response.code
+            when {
+                response.isSuccessful -> parseUsageBody(response)
+                code == HTTP_UNAUTHORIZED || code == HTTP_FORBIDDEN ->
+                    UsageResponse.Failure.Auth(
+                        "GitHub rejected the PAT (HTTP $code). " +
+                            "Ensure the token has billing read permission."
+                    )
+                code == HTTP_TOO_MANY_REQUESTS ->
+                    UsageResponse.Failure.RateLimited(rateLimitMessage(response))
+                code >= HTTP_INTERNAL_ERROR ->
+                    UsageResponse.Failure.Network("GitHub API server error: $code")
+                else ->
+                    UsageResponse.Failure.Network("GitHub API error: $code")
+            }
+        }
+    }
+
+    private fun parseUsageBody(response: Response): UsageResponse {
+        val body = response.body?.string()
+            ?: return UsageResponse.Failure.Network("Empty response body")
+        return try {
+            val json = gson.fromJson(body, JsonObject::class.java)
+                ?: return UsageResponse.Failure.Parse("GitHub returned empty JSON", null)
+            val items = json.getAsJsonArray("usageItems")
+            if (items == null) {
+                // Empty period is a valid state — no items means $0 usage.
+                return UsageResponse.Success(BigDecimal.ZERO, 0)
+            }
+            var netTotal = BigDecimal.ZERO
+            var count = 0
+            items.forEach { element ->
+                if (!element.isJsonObject) return@forEach
+                val item = element.asJsonObject
+                val net = item.get("netAmount")?.takeIf { it.isJsonPrimitive }
+                    ?.asBigDecimal
+                    ?: BigDecimal.ZERO
+                netTotal = netTotal.add(net)
+                count += 1
+            }
+            UsageResponse.Success(netTotal, count)
+        } catch (e: Exception) {
+            UsageResponse.Failure.Parse("Failed to parse GitHub usage response", e)
+        }
+    }
+
+    private fun rateLimitMessage(response: Response): String {
+        val retryAfter = response.header("Retry-After")?.trim()
+        return if (!retryAfter.isNullOrEmpty()) {
+            "GitHub API rate limit exceeded. Retry after ${retryAfter}s."
+        } else {
+            "GitHub API rate limit exceeded"
+        }
+    }
+
+    internal sealed class UsageResponse {
+        data class Success(val netAmount: BigDecimal, val itemCount: Int) : UsageResponse()
+        sealed class Failure : UsageResponse() {
+            abstract fun toFailure(): ProviderResult.Failure
+            data class Auth(val message: String) : Failure() {
+                override fun toFailure() = ProviderResult.Failure.AuthError(message)
+            }
+            data class RateLimited(val message: String) : Failure() {
+                override fun toFailure() = ProviderResult.Failure.RateLimited(message)
+            }
+            data class Network(val message: String) : Failure() {
+                override fun toFailure() = ProviderResult.Failure.NetworkError(message)
+            }
+            data class Parse(val message: String, val cause: Throwable?) : Failure() {
+                override fun toFailure() = ProviderResult.Failure.ParseError(message, cause)
+            }
+        }
+    }
+
+    companion object {
+        const val GITHUB_API_BASE_URL = "https://api.github.com"
+        const val GITHUB_ACCEPT = "application/vnd.github+json"
+        const val GITHUB_API_VERSION = "2026-03-10"
+        private const val PRODUCT_PREMIUM_REQUEST = "premium_request"
+        private const val PRODUCT_AI_CREDIT = "ai_credit"
+        private const val HTTP_UNAUTHORIZED = 401
+        private const val HTTP_FORBIDDEN = 403
+        private const val HTTP_TOO_MANY_REQUESTS = 429
+        private const val HTTP_INTERNAL_ERROR = 500
+    }
+}

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/github/GitHubSecrets.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/provider/github/GitHubSecrets.kt
@@ -1,0 +1,61 @@
+package org.zhavoronkov.tokenpulse.provider.github
+
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+
+/**
+ * Parsed personal-billing secret for [GitHubCopilotProviderClient].
+ *
+ * Serialized form (stored in PasswordSafe): {"pat":"...","username":"..."}
+ */
+internal data class GitHubCopilotSecret(val pat: String, val username: String)
+
+/**
+ * Parsed org-billing secret for [GitHubCopilotBudgetProviderClient].
+ *
+ * Serialized form (stored in PasswordSafe): {"pat":"...","org":"..."}
+ */
+internal data class GitHubOrgBudgetSecret(val pat: String, val org: String)
+
+/**
+ * Serialize/parse helpers for the GitHub connect-dialog secret blobs.
+ *
+ * The connect dialogs pack the PAT together with the username/org (both
+ * required to build the REST endpoint path) into a small JSON object. The
+ * provider clients unpack it here. Parsing is defensive: a missing or blank
+ * field yields null so the caller can surface a clean auth error rather than
+ * throwing.
+ */
+internal object GitHubSecrets {
+    private val gson = Gson()
+
+    fun encodeCopilot(pat: String, username: String): String =
+        gson.toJson(mapOf("pat" to pat, "username" to username))
+
+    fun encodeOrgBudget(pat: String, org: String): String =
+        gson.toJson(mapOf("pat" to pat, "org" to org))
+
+    fun parseCopilot(secret: String): GitHubCopilotSecret? {
+        val obj = parseObject(secret) ?: return null
+        val pat = obj.stringOrNull("pat") ?: return null
+        val username = obj.stringOrNull("username") ?: return null
+        return GitHubCopilotSecret(pat, username)
+    }
+
+    fun parseOrgBudget(secret: String): GitHubOrgBudgetSecret? {
+        val obj = parseObject(secret) ?: return null
+        val pat = obj.stringOrNull("pat") ?: return null
+        val org = obj.stringOrNull("org") ?: return null
+        return GitHubOrgBudgetSecret(pat, org)
+    }
+
+    private fun parseObject(secret: String): JsonObject? =
+        try {
+            gson.fromJson(secret, JsonObject::class.java)
+        } catch (_: Exception) {
+            null
+        }
+
+    private fun JsonObject.stringOrNull(key: String): String? =
+        get(key)?.takeIf { it.isJsonPrimitive }?.asString?.trim()?.takeIf { it.isNotEmpty() }
+}

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/service/BalanceRefreshService.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/service/BalanceRefreshService.kt
@@ -345,7 +345,9 @@ internal fun isApiKeyAuth(authType: AuthType): Boolean = when (authType) {
     AuthType.OPENAI_API_KEY,
     AuthType.XIAOMI_API_KEY,
     AuthType.XIAOMI_TOKEN_PLAN_KEY,
-    AuthType.OPENROUTER_PROVISIONING_KEY -> true
+    AuthType.OPENROUTER_PROVISIONING_KEY,
+    AuthType.GITHUB_COPILOT_PAT,
+    AuthType.GITHUB_COPILOT_ORG_BUDGET_PAT -> true
     AuthType.CLAUDE_CODE_LOCAL,
     AuthType.CODEX_CLI_LOCAL,
     AuthType.OPENAI_OAUTH,

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/settings/Account.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/settings/Account.kt
@@ -78,7 +78,27 @@ enum class AuthType(val displayName: String) {
      * both pay-as-you-go balance and Token Plan usage from the same session.
      * No API key is involved (the sk-/tp- keys were inference-only).
      */
-    XIAOMI_SESSION("Session")
+    XIAOMI_SESSION("Session"),
+
+    /**
+     * GitHub Copilot personal billing (per-user usage).
+     *
+     * The stored secret is a JSON blob: {"pat":"...","username":"..."}
+     * where `pat` is a Personal Access Token with billing read permission,
+     * and `username` is the GitHub username (required for the endpoint path).
+     * Tracks premium_request spend (headline) and ai_credit spend (metadata).
+     */
+    GITHUB_COPILOT_PAT("Personal Access Token"),
+
+    /**
+     * GitHub Copilot org billing (budget tracking).
+     *
+     * The stored secret is a JSON blob: {"pat":"...","org":"..."}
+     * where `pat` is a Personal Access Token with org admin/billing-manager
+     * permissions, and `org` is the GitHub organization name.
+     * Tracks budget_amount and consumed_amount for Copilot-related budgets.
+     */
+    GITHUB_COPILOT_ORG_BUDGET_PAT("Org Billing PAT")
 }
 
 /**

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/AccountEditDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/AccountEditDialog.kt
@@ -77,7 +77,9 @@ class AccountEditDialog(
             ConnectionType.OPENROUTER_PLUGIN,
             ConnectionType.XIAOMI,
             ConnectionType.XIAOMI_API,
-            ConnectionType.XIAOMI_TOKEN_PLAN
+            ConnectionType.XIAOMI_TOKEN_PLAN,
+            ConnectionType.GITHUB_COPILOT_PAT,
+            ConnectionType.GITHUB_COPILOT_ORG_BUDGET
         )
     }
 
@@ -179,6 +181,9 @@ class AccountEditDialog(
     private val xiaomiConnectButton = JButton("Connect Xiaomi Account →").apply {
         addActionListener { openXiaomiConnectDialog() }
     }
+
+    // ── GitHub Copilot (personal) connect button ──────────────────────────
+    private val gitHubPanel = GitHubProviderPanel(existingSecret)
 
     private val enabledCheckBox = JCheckBox("Account enabled", account?.isEnabled ?: true)
 
@@ -302,6 +307,11 @@ class AccountEditDialog(
         xiaomiStatusLabel.isVisible = isXiaomi
 
         providerHintLabel.text = "<html><font color='gray'>${keyHintFor(connectionType)}</font></html>"
+
+        gitHubPanel.copilotConnectButton.isVisible = connectionType == ConnectionType.GITHUB_COPILOT_PAT
+        gitHubPanel.copilotStatusLabel.isVisible = connectionType == ConnectionType.GITHUB_COPILOT_PAT
+        gitHubPanel.orgConnectButton.isVisible = connectionType == ConnectionType.GITHUB_COPILOT_ORG_BUDGET
+        gitHubPanel.orgStatusLabel.isVisible = connectionType == ConnectionType.GITHUB_COPILOT_ORG_BUDGET
     }
 
     /**
@@ -328,6 +338,8 @@ class AccountEditDialog(
         ConnectionType.XIAOMI,
         ConnectionType.XIAOMI_API,
         ConnectionType.XIAOMI_TOKEN_PLAN -> capturedXiaomiSession ?: ""
+        ConnectionType.GITHUB_COPILOT_PAT,
+        ConnectionType.GITHUB_COPILOT_ORG_BUDGET -> gitHubPanel.getSecret(getConnectionType())
         else -> String(keyField.password).trim()
     }
 
@@ -362,6 +374,8 @@ class AccountEditDialog(
         ConnectionType.XIAOMI,
         ConnectionType.XIAOMI_API,
         ConnectionType.XIAOMI_TOKEN_PLAN -> "https://platform.xiaomimimo.com/console/api-keys"
+        ConnectionType.GITHUB_COPILOT_PAT -> "https://github.com/settings/tokens?type=beta"
+        ConnectionType.GITHUB_COPILOT_ORG_BUDGET -> "https://github.com/settings/tokens?type=beta"
     }
 
     private fun openNebiusConnectDialog() {
@@ -555,6 +569,12 @@ class AccountEditDialog(
         ConnectionType.XIAOMI_TOKEN_PLAN ->
             "Xiaomi MiMo. Click \"Connect Xiaomi Account →\" to sign in and capture your platform session. " +
                 "Tracks both pay-as-you-go balance and Token Plan usage."
+        ConnectionType.GITHUB_COPILOT_PAT ->
+            "GitHub Copilot personal usage. Click \"Connect GitHub Copilot →\" to enter your username and a " +
+                "Personal Access Token with billing read permission. Shows your premium-request spend."
+        ConnectionType.GITHUB_COPILOT_ORG_BUDGET ->
+            "GitHub Copilot organization budgets. Click \"Connect GitHub Copilot Org →\" to enter your org and " +
+                "an admin/billing-manager PAT. Shows remaining vs. consumed budget."
     }
 
     // ── Panel construction ─────────────────────────────────────────────────
@@ -576,7 +596,9 @@ class AccountEditDialog(
                     it != ConnectionType.CODEX_CLI &&
                     it != ConnectionType.CLAUDE_CODE &&
                     it != ConnectionType.OPENROUTER_PLUGIN &&
-                    it !in XIAOMI_TYPES
+                    it !in XIAOMI_TYPES &&
+                    it != ConnectionType.GITHUB_COPILOT_PAT &&
+                    it != ConnectionType.GITHUB_COPILOT_ORG_BUDGET
             }
         )
 
@@ -647,6 +669,22 @@ class AccountEditDialog(
             connectionTypeCombo.selectedValueMatches { it in XIAOMI_TYPES }
         )
 
+        // --- GitHub Copilot (personal) Row ---
+        row {
+            cell(gitHubPanel.copilotConnectButton)
+            cell(gitHubPanel.copilotStatusLabel)
+        }.visibleIf(
+            connectionTypeCombo.selectedValueMatches { it == ConnectionType.GITHUB_COPILOT_PAT }
+        )
+
+        // --- GitHub Copilot (org) Row ---
+        row {
+            cell(gitHubPanel.orgConnectButton)
+            cell(gitHubPanel.orgStatusLabel)
+        }.visibleIf(
+            connectionTypeCombo.selectedValueMatches { it == ConnectionType.GITHUB_COPILOT_ORG_BUDGET }
+        )
+
         separator()
 
         row {
@@ -680,7 +718,9 @@ class AccountEditDialog(
             account.connectionType != ConnectionType.NEBIUS_BILLING &&
             account.connectionType != ConnectionType.CODEX_CLI &&
             account.connectionType != ConnectionType.CLAUDE_CODE &&
-            account.connectionType !in XIAOMI_TYPES
+            account.connectionType !in XIAOMI_TYPES &&
+            account.connectionType != ConnectionType.GITHUB_COPILOT_PAT &&
+            account.connectionType != ConnectionType.GITHUB_COPILOT_ORG_BUDGET
     }
 
     // ── Public accessors ───────────────────────────────────────────────────
@@ -698,6 +738,8 @@ class AccountEditDialog(
             ConnectionType.XIAOMI,
             ConnectionType.XIAOMI_API,
             ConnectionType.XIAOMI_TOKEN_PLAN -> validateXiaomi()
+            ConnectionType.GITHUB_COPILOT_PAT,
+            ConnectionType.GITHUB_COPILOT_ORG_BUDGET -> gitHubPanel.validate(getConnectionType())
             else -> validateOther()
         }
     }

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/AccountEditDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/AccountEditDialog.kt
@@ -187,7 +187,7 @@ class AccountEditDialog(
 
     private val enabledCheckBox = JCheckBox("Account enabled", account?.isEnabled ?: true)
 
-    private val providerHintLabel = JBLabel("<html><small></small></html>")
+    private lateinit var providerHintLabel: com.intellij.ui.dsl.builder.Cell<javax.swing.JEditorPane>
 
     // ── Claude Code name field (editable label; email/org or dir basename) ──
     private val nameField = JBTextField(account?.name ?: "").apply {
@@ -306,7 +306,7 @@ class AccountEditDialog(
         xiaomiConnectButton.isVisible = isXiaomi
         xiaomiStatusLabel.isVisible = isXiaomi
 
-        providerHintLabel.text = "<html><font color='gray'>${keyHintFor(connectionType)}</font></html>"
+        providerHintLabel.component.text = "<html>${keyHintFor(connectionType)}</html>"
 
         gitHubPanel.copilotConnectButton.isVisible = connectionType == ConnectionType.GITHUB_COPILOT_PAT
         gitHubPanel.copilotStatusLabel.isVisible = connectionType == ConnectionType.GITHUB_COPILOT_PAT
@@ -692,7 +692,7 @@ class AccountEditDialog(
         }
 
         row {
-            cell(providerHintLabel).align(AlignX.FILL)
+            providerHintLabel = comment("")
         }
 
         row {

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/AccountEditDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/AccountEditDialog.kt
@@ -306,7 +306,8 @@ class AccountEditDialog(
         xiaomiConnectButton.isVisible = isXiaomi
         xiaomiStatusLabel.isVisible = isXiaomi
 
-        providerHintLabel.component.text = "<html>${keyHintFor(connectionType)}</html>"
+        providerHintLabel.component.text = keyHintFor(connectionType)
+        window?.pack()
 
         gitHubPanel.copilotConnectButton.isVisible = connectionType == ConnectionType.GITHUB_COPILOT_PAT
         gitHubPanel.copilotStatusLabel.isVisible = connectionType == ConnectionType.GITHUB_COPILOT_PAT

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/GitHubCopilotConnectDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/GitHubCopilotConnectDialog.kt
@@ -1,0 +1,120 @@
+package org.zhavoronkov.tokenpulse.ui
+
+import com.intellij.ide.BrowserUtil
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBPasswordField
+import com.intellij.ui.components.JBTextField
+import com.intellij.ui.dsl.builder.AlignX
+import com.intellij.ui.dsl.builder.panel
+import org.zhavoronkov.tokenpulse.provider.github.GitHubSecrets
+import org.zhavoronkov.tokenpulse.utils.Constants.FONT_SIZE_SMALL
+import org.zhavoronkov.tokenpulse.utils.Constants.PASSWORD_FIELD_COLUMNS
+import java.awt.Font
+import javax.swing.JButton
+import javax.swing.JComponent
+
+/**
+ * Dialog for connecting GitHub Copilot personal billing (per-user usage).
+ *
+ * Captures a Personal Access Token (with billing read permission) and the
+ * GitHub username. Both are required for the `/users/{username}/settings/billing/...`
+ * endpoints.
+ *
+ * To create a PAT with billing read permission:
+ * 1. Go to https://github.com/settings/tokens?type=beta
+ * 2. Create a new fine-grained PAT with "Plan" (billing) read permission, or
+ *    a classic PAT with `read:user` + billing scope.
+ * 3. Enter your GitHub username and paste the PAT below.
+ */
+class GitHubCopilotConnectDialog : DialogWrapper(true) {
+
+    companion object {
+        private const val GITHUB_TOKENS_URL = "https://github.com/settings/tokens?type=beta"
+        private const val STATUS_WAITING =
+            "<html><i>Enter your GitHub username and PAT (fine-grained or classic)</i></html>"
+        private const val STATUS_SUCCESS = "<html><font color='green'><b>✓ Credentials captured!</b></font></html>"
+        private const val STATUS_EMPTY = "<html><font color='red'>Please fill in both username and PAT.</font></html>"
+        private const val STEP2_HTML =
+            "<html><b>Step 2:</b> Use fine-grained PAT with \"Plan\" read permission,<br>" +
+                "or classic PAT with <code>read:user</code> + billing scope.</html>"
+    }
+
+    var capturedSecretJson: String? = null
+        private set
+
+    private val statusLabel = JBLabel(STATUS_WAITING)
+
+    private val usernameField = JBTextField().apply {
+        columns = 20
+        toolTipText = "Your GitHub username (e.g., 'octocat')"
+    }
+
+    private val patField = JBPasswordField().apply {
+        columns = PASSWORD_FIELD_COLUMNS
+        font = Font(Font.MONOSPACED, Font.PLAIN, FONT_SIZE_SMALL)
+        toolTipText = "Personal Access Token with billing read permission"
+    }
+
+    private val captureButton = JButton("Capture").apply {
+        addActionListener { attemptCapture() }
+    }
+
+    private val openBrowserButton = JButton("Generate Token").apply {
+        addActionListener { BrowserUtil.browse(GITHUB_TOKENS_URL) }
+    }
+
+    init {
+        title = "Connect GitHub Copilot (Personal)"
+        setOKButtonText("Connect")
+        isOKActionEnabled = false
+        init()
+    }
+
+    override fun createCenterPanel(): JComponent = panel {
+        row {
+            label("<html><b>GitHub Copilot Personal Billing</b></html>")
+        }
+        row {
+            label("<html>Tracks your per-user Copilot premium-request spend.</html>")
+        }
+        row {
+            label("<html><b>Step 1:</b> Create a Personal Access Token</html>")
+        }
+        row {
+            cell(openBrowserButton)
+        }
+        row {
+            label(STEP2_HTML)
+        }
+        row {
+            label("<html><b>Step 3:</b> Enter your GitHub username and paste the PAT:</html>")
+        }
+        row("Username:") {
+            cell(usernameField).align(AlignX.FILL)
+        }
+        row("PAT:") {
+            cell(patField).align(AlignX.FILL)
+        }
+        row {
+            cell(captureButton)
+            cell(statusLabel).align(AlignX.FILL)
+        }
+    }
+
+    override fun getPreferredFocusedComponent() = usernameField
+
+    private fun attemptCapture() {
+        val username = usernameField.text.trim()
+        val pat = String(patField.password).trim()
+
+        if (username.isEmpty() || pat.isEmpty()) {
+            statusLabel.text = STATUS_EMPTY
+            return
+        }
+
+        capturedSecretJson = GitHubSecrets.encodeCopilot(pat, username)
+        statusLabel.text = STATUS_SUCCESS
+        isOKActionEnabled = true
+    }
+}

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/GitHubCopilotConnectDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/GitHubCopilotConnectDialog.kt
@@ -76,7 +76,7 @@ class GitHubCopilotConnectDialog : DialogWrapper(true) {
             label("<html><b>GitHub Copilot Personal Billing</b></html>")
         }
         row {
-            label("<html>Tracks your per-user Copilot premium-request spend.</html>")
+            comment("Tracks your per-user Copilot premium-request spend.")
         }
         row {
             label("<html><b>Step 1:</b> Create a Personal Access Token</html>")
@@ -85,7 +85,7 @@ class GitHubCopilotConnectDialog : DialogWrapper(true) {
             cell(openBrowserButton)
         }
         row {
-            label(STEP2_HTML)
+            comment(DslCommentText.sanitize(STEP2_HTML))
         }
         row {
             label("<html><b>Step 3:</b> Enter your GitHub username and paste the PAT:</html>")

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/GitHubCopilotOrgConnectDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/GitHubCopilotOrgConnectDialog.kt
@@ -75,7 +75,7 @@ class GitHubCopilotOrgConnectDialog : DialogWrapper(true) {
             label("<html><b>GitHub Copilot Organization Billing</b></html>")
         }
         row {
-            label("<html>Tracks your org's Copilot budget limits and consumption.</html>")
+            comment("Tracks your org's Copilot budget limits and consumption.")
         }
         row {
             label("<html><b>Step 1:</b> Create a Personal Access Token</html>")
@@ -84,7 +84,7 @@ class GitHubCopilotOrgConnectDialog : DialogWrapper(true) {
             cell(openBrowserButton)
         }
         row {
-            label(STEP2_HTML)
+            comment(DslCommentText.sanitize(STEP2_HTML))
         }
         row {
             label("<html><b>Step 3:</b> Enter your org name and paste the PAT:</html>")

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/GitHubCopilotOrgConnectDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/GitHubCopilotOrgConnectDialog.kt
@@ -1,0 +1,119 @@
+package org.zhavoronkov.tokenpulse.ui
+
+import com.intellij.ide.BrowserUtil
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBPasswordField
+import com.intellij.ui.components.JBTextField
+import com.intellij.ui.dsl.builder.AlignX
+import com.intellij.ui.dsl.builder.panel
+import org.zhavoronkov.tokenpulse.provider.github.GitHubSecrets
+import org.zhavoronkov.tokenpulse.utils.Constants.FONT_SIZE_SMALL
+import org.zhavoronkov.tokenpulse.utils.Constants.PASSWORD_FIELD_COLUMNS
+import java.awt.Font
+import javax.swing.JButton
+import javax.swing.JComponent
+
+/**
+ * Dialog for connecting GitHub Copilot organization billing (budgets).
+ *
+ * Captures a Personal Access Token (with org admin / billing-manager permissions)
+ * and the GitHub organization name. Both are required for the
+ * `/organizations/{org}/settings/billing/budgets` endpoint.
+ *
+ * To create a PAT with org admin/billing-manager permissions:
+ * 1. Go to https://github.com/settings/tokens?type=beta
+ * 2. Create a new fine-grained PAT with org admin or billing-manager role, or
+ *    a classic PAT with `admin:org_hook` scope.
+ * 3. Enter your org name and paste the PAT below.
+ */
+class GitHubCopilotOrgConnectDialog : DialogWrapper(true) {
+
+    companion object {
+        private const val GITHUB_TOKENS_URL = "https://github.com/settings/tokens?type=beta"
+        private const val STATUS_WAITING = "<html><i>Enter your org name and an admin/billing-manager PAT</i></html>"
+        private const val STATUS_SUCCESS = "<html><font color='green'><b>✓ Credentials captured!</b></font></html>"
+        private const val STATUS_EMPTY = "<html><font color='red'>Please fill in both org name and PAT.</font></html>"
+        private const val STEP2_HTML =
+            "<html><b>Step 2:</b> Use fine-grained PAT with org admin/billing-manager role,<br>" +
+                "or classic PAT with <code>admin:org_hook</code> scope.</html>"
+    }
+
+    var capturedSecretJson: String? = null
+        private set
+
+    private val statusLabel = JBLabel(STATUS_WAITING)
+
+    private val orgField = JBTextField().apply {
+        columns = 20
+        toolTipText = "Your GitHub organization name (e.g., 'my-company')"
+    }
+
+    private val patField = JBPasswordField().apply {
+        columns = PASSWORD_FIELD_COLUMNS
+        font = Font(Font.MONOSPACED, Font.PLAIN, FONT_SIZE_SMALL)
+        toolTipText = "Personal Access Token with org admin/billing-manager permissions"
+    }
+
+    private val captureButton = JButton("Capture").apply {
+        addActionListener { attemptCapture() }
+    }
+
+    private val openBrowserButton = JButton("Generate Token").apply {
+        addActionListener { BrowserUtil.browse(GITHUB_TOKENS_URL) }
+    }
+
+    init {
+        title = "Connect GitHub Copilot (Organization)"
+        setOKButtonText("Connect")
+        isOKActionEnabled = false
+        init()
+    }
+
+    override fun createCenterPanel(): JComponent = panel {
+        row {
+            label("<html><b>GitHub Copilot Organization Billing</b></html>")
+        }
+        row {
+            label("<html>Tracks your org's Copilot budget limits and consumption.</html>")
+        }
+        row {
+            label("<html><b>Step 1:</b> Create a Personal Access Token</html>")
+        }
+        row {
+            cell(openBrowserButton)
+        }
+        row {
+            label(STEP2_HTML)
+        }
+        row {
+            label("<html><b>Step 3:</b> Enter your org name and paste the PAT:</html>")
+        }
+        row("Org:") {
+            cell(orgField).align(AlignX.FILL)
+        }
+        row("PAT:") {
+            cell(patField).align(AlignX.FILL)
+        }
+        row {
+            cell(captureButton)
+            cell(statusLabel).align(AlignX.FILL)
+        }
+    }
+
+    override fun getPreferredFocusedComponent() = orgField
+
+    private fun attemptCapture() {
+        val org = orgField.text.trim()
+        val pat = String(patField.password).trim()
+
+        if (org.isEmpty() || pat.isEmpty()) {
+            statusLabel.text = STATUS_EMPTY
+            return
+        }
+
+        capturedSecretJson = GitHubSecrets.encodeOrgBudget(pat, org)
+        statusLabel.text = STATUS_SUCCESS
+        isOKActionEnabled = true
+    }
+}

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/GitHubProviderPanel.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/GitHubProviderPanel.kt
@@ -1,0 +1,102 @@
+package org.zhavoronkov.tokenpulse.ui
+
+import com.intellij.openapi.ui.ValidationInfo
+import com.intellij.ui.components.JBLabel
+import org.zhavoronkov.tokenpulse.model.ConnectionType
+import javax.swing.JButton
+
+/**
+ * Helper for AccountEditDialog to manage GitHub Copilot provider UI state.
+ *
+ * Owns:
+ * - Connect buttons and status labels for both personal and org billing
+ * - Captured secret state for both types
+ * - Dialog-opener and validation logic
+ *
+ * This extraction keeps AccountEditDialog under the function count threshold.
+ */
+internal class GitHubProviderPanel(private val existingSecret: String?) {
+
+    val copilotConnectButton = JButton("Connect GitHub Copilot →").apply {
+        addActionListener { openGitHubCopilotConnectDialog() }
+    }
+
+    val copilotStatusLabel = JBLabel(
+        if (!existingSecret.isNullOrBlank()) {
+            "<html><font color='green'>✓ Connected</font></html>"
+        } else {
+            "<html><i>Not connected</i></html>"
+        }
+    )
+
+    val orgConnectButton = JButton("Connect GitHub Copilot Org →").apply {
+        addActionListener { openGitHubCopilotOrgConnectDialog() }
+    }
+
+    val orgStatusLabel = JBLabel(
+        if (!existingSecret.isNullOrBlank()) {
+            "<html><font color='green'>✓ Connected</font></html>"
+        } else {
+            "<html><i>Not connected</i></html>"
+        }
+    )
+
+    var capturedCopilotSecret: String? = existingSecret
+    var capturedOrgSecret: String? = existingSecret
+
+    fun getSecret(connectionType: ConnectionType): String = when (connectionType) {
+        ConnectionType.GITHUB_COPILOT_PAT -> capturedCopilotSecret ?: ""
+        ConnectionType.GITHUB_COPILOT_ORG_BUDGET -> capturedOrgSecret ?: ""
+        else -> ""
+    }
+
+    fun validate(connectionType: ConnectionType): ValidationInfo? = when (connectionType) {
+        ConnectionType.GITHUB_COPILOT_PAT -> validateCopilot()
+        ConnectionType.GITHUB_COPILOT_ORG_BUDGET -> validateOrg()
+        else -> null
+    }
+
+    private fun openGitHubCopilotConnectDialog() {
+        val dialog = GitHubCopilotConnectDialog()
+        if (dialog.showAndGet()) {
+            val json = dialog.capturedSecretJson
+            if (!json.isNullOrBlank()) {
+                capturedCopilotSecret = json
+                copilotStatusLabel.text =
+                    "<html><font color='green'><b>✓ Connected</b></font></html>"
+            }
+        }
+    }
+
+    private fun openGitHubCopilotOrgConnectDialog() {
+        val dialog = GitHubCopilotOrgConnectDialog()
+        if (dialog.showAndGet()) {
+            val json = dialog.capturedSecretJson
+            if (!json.isNullOrBlank()) {
+                capturedOrgSecret = json
+                orgStatusLabel.text =
+                    "<html><font color='green'><b>✓ Connected</b></font></html>"
+            }
+        }
+    }
+
+    private fun validateCopilot(): ValidationInfo? {
+        if (capturedCopilotSecret.isNullOrBlank()) {
+            return ValidationInfo(
+                "Please connect your GitHub Copilot account first.",
+                copilotConnectButton
+            )
+        }
+        return null
+    }
+
+    private fun validateOrg(): ValidationInfo? {
+        if (capturedOrgSecret.isNullOrBlank()) {
+            return ValidationInfo(
+                "Please connect your GitHub Copilot org first.",
+                orgConnectButton
+            )
+        }
+        return null
+    }
+}

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/NebiusConnectDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/NebiusConnectDialog.kt
@@ -74,10 +74,10 @@ class NebiusConnectDialog : DialogWrapper(true) {
             label("<html><b>Method: cURL (Required)</b></html>")
         }
         row {
-            label("<html>1. Open Nebius, login, then DevTools → <b>Network</b>.</html>")
+            comment("1. Open Nebius, login, then DevTools → <b>Network</b>.")
         }
         row {
-            label("<html>2. Refresh, filter by \"getBalance\", right-click → <b>Copy as cURL</b>.</html>")
+            comment("2. Refresh, filter by \"getBalance\", right-click → <b>Copy as cURL</b>.")
         }
         row {
             label("<html>3. Paste result below and click Validate.</html>")

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/OpenAiConnectDialog.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/ui/OpenAiConnectDialog.kt
@@ -76,13 +76,13 @@ class OpenAiConnectDialog : DialogWrapper(true) {
             label("<html><b>OpenAI Admin Key Connection</b></html>")
         }
         row {
-            label("<html>1. Open the OpenAI Admin keys page (org level).</html>")
+            comment("1. Open the OpenAI Admin keys page (org level).")
         }
         row {
             cell(openBrowserButton)
         }
         row {
-            label("<html>2. Create key with <b>Usage API Scope = read</b>.</html>")
+            comment("2. Create key with <b>Usage API Scope = read</b>.")
         }
         row {
             label("<html>3. Paste key (sk-admin-...) below:</html>")

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/model/ProviderTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/model/ProviderTest.kt
@@ -66,7 +66,13 @@ class ProviderTest {
     }
 
     @Test
-    fun `there are exactly 7 providers`() {
-        assertEquals(7, Provider.entries.size)
+    fun `GITHUB has correct display name and short code`() {
+        assertEquals("GitHub Copilot", Provider.GITHUB.displayName)
+        assertEquals("GH", Provider.GITHUB.abbreviation)
+    }
+
+    @Test
+    fun `there are exactly 8 providers`() {
+        assertEquals(8, Provider.entries.size)
     }
 }

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/GitHubCopilotBudgetProviderClientTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/GitHubCopilotBudgetProviderClientTest.kt
@@ -1,0 +1,217 @@
+package org.zhavoronkov.tokenpulse.provider
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.zhavoronkov.tokenpulse.model.ConnectionType
+import org.zhavoronkov.tokenpulse.model.ProviderResult
+import org.zhavoronkov.tokenpulse.provider.github.GitHubCopilotBudgetProviderClient
+import org.zhavoronkov.tokenpulse.provider.github.GitHubSecrets
+import org.zhavoronkov.tokenpulse.settings.Account
+import org.zhavoronkov.tokenpulse.settings.AuthType
+import java.math.BigDecimal
+
+/**
+ * Unit tests for [GitHubCopilotBudgetProviderClient] using MockWebServer.
+ *
+ * Verifies:
+ * - Successful parsing of org budgets endpoint
+ * - Filtering to Copilot-relevant SKUs (ai_credits, premium_requests)
+ * - Sum-of-budget and sum-of-consumed aggregation
+ * - Remaining balance calculation (total - used)
+ * - RFC 5988 Link header pagination
+ * - Auth (401/403), rate-limit (429), and server (5xx) error mapping
+ * - Rejection of malformed secret payloads
+ */
+class GitHubCopilotBudgetProviderClientTest {
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var client: GitHubCopilotBudgetProviderClient
+    private val account = Account(
+        connectionType = ConnectionType.GITHUB_COPILOT_ORG_BUDGET,
+        authType = AuthType.GITHUB_COPILOT_ORG_BUDGET_PAT
+    )
+    private val validSecret = GitHubSecrets.encodeOrgBudget("ghp_testtoken", "my-org")
+
+    @BeforeEach
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+        client = GitHubCopilotBudgetProviderClient(
+            baseUrl = mockWebServer.url("/").toString().trimEnd('/')
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun `fetchBalance sums budgets and consumed amounts for Copilot SKUs`() {
+        mockWebServer.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{
+                    "budgets": [
+                        {
+                            "budget_product_sku": "ai_credits",
+                            "budget_amount": 1000.00,
+                            "consumed_amount": 250.00
+                        },
+                        {
+                            "budget_product_sku": "premium_requests",
+                            "budget_amount": 500.00,
+                            "consumed_amount": 100.00
+                        }
+                    ]
+                }"""
+            )
+        )
+
+        val result = client.fetchBalance(account, validSecret)
+
+        assertTrue(result is ProviderResult.Success)
+        val success = result as ProviderResult.Success
+        assertEquals(0, BigDecimal("1500.00").compareTo(success.snapshot.balance.credits?.total))
+        assertEquals(0, BigDecimal("350.00").compareTo(success.snapshot.balance.credits?.used))
+        assertEquals(0, BigDecimal("1150.00").compareTo(success.snapshot.balance.credits?.remaining))
+        assertEquals("USD", success.snapshot.metadata["currency"])
+        assertEquals("my-org", success.snapshot.metadata["org"])
+        assertEquals("2", success.snapshot.metadata["budgetCount"])
+    }
+
+    @Test
+    fun `fetchBalance filters out non-Copilot SKUs`() {
+        mockWebServer.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{
+                    "budgets": [
+                        {
+                            "budget_product_sku": "ai_credits",
+                            "budget_amount": 100.00,
+                            "consumed_amount": 10.00
+                        },
+                        {
+                            "budget_product_sku": "actions_minutes",
+                            "budget_amount": 1000.00,
+                            "consumed_amount": 500.00
+                        }
+                    ]
+                }"""
+            )
+        )
+
+        val result = client.fetchBalance(account, validSecret)
+
+        assertTrue(result is ProviderResult.Success)
+        val success = result as ProviderResult.Success
+        // Only ai_credits should be counted
+        assertEquals(0, BigDecimal("100.00").compareTo(success.snapshot.balance.credits?.total))
+        assertEquals(0, BigDecimal("10.00").compareTo(success.snapshot.balance.credits?.used))
+    }
+
+    @Test
+    fun `fetchBalance handles pagination with Link header`() {
+        // First page
+        mockWebServer.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader(
+                    "Link",
+                    "<${mockWebServer.url("/page2")}>; rel=\"next\""
+                )
+                .setBody(
+                    """{
+                        "budgets": [
+                            {
+                                "budget_product_sku": "ai_credits",
+                                "budget_amount": 100.00,
+                                "consumed_amount": 10.00
+                            }
+                        ]
+                    }"""
+                )
+        )
+        // Second page
+        mockWebServer.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{
+                    "budgets": [
+                        {
+                            "budget_product_sku": "premium_requests",
+                            "budget_amount": 50.00,
+                            "consumed_amount": 5.00
+                        }
+                    ]
+                }"""
+            )
+        )
+
+        val result = client.fetchBalance(account, validSecret)
+
+        assertTrue(result is ProviderResult.Success)
+        val success = result as ProviderResult.Success
+        // Should sum both pages
+        assertEquals(0, BigDecimal("150.00").compareTo(success.snapshot.balance.credits?.total))
+        assertEquals(0, BigDecimal("15.00").compareTo(success.snapshot.balance.credits?.used))
+    }
+
+    @Test
+    fun `fetchBalance maps 401 to AuthError`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(401))
+        val result = client.fetchBalance(account, validSecret)
+        assertTrue(result is ProviderResult.Failure.AuthError)
+    }
+
+    @Test
+    fun `fetchBalance maps 403 to AuthError`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(403))
+        val result = client.fetchBalance(account, validSecret)
+        assertTrue(result is ProviderResult.Failure.AuthError)
+    }
+
+    @Test
+    fun `fetchBalance maps 429 to RateLimited`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(429))
+        val result = client.fetchBalance(account, validSecret)
+        assertTrue(result is ProviderResult.Failure.RateLimited)
+    }
+
+    @Test
+    fun `fetchBalance maps 500 to NetworkError`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(500))
+        val result = client.fetchBalance(account, validSecret)
+        assertTrue(result is ProviderResult.Failure.NetworkError)
+    }
+
+    @Test
+    fun `fetchBalance rejects malformed secret payload with AuthError`() {
+        val result = client.fetchBalance(account, "not-a-json-blob")
+        assertTrue(result is ProviderResult.Failure.AuthError)
+    }
+
+    @Test
+    fun `fetchBalance rejects secret missing org with AuthError`() {
+        val result = client.fetchBalance(account, """{"pat":"ghp_x"}""")
+        assertTrue(result is ProviderResult.Failure.AuthError)
+    }
+
+    @Test
+    fun `testCredentials returns success without full snapshot`() {
+        mockWebServer.enqueue(
+            MockResponse().setResponseCode(200).setBody("""{"budgets": []}""")
+        )
+        val result = client.testCredentials(account, validSecret)
+        assertTrue(result is ProviderResult.Success)
+    }
+
+    @Test
+    fun `testCredentials returns AuthError on 403`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(403))
+        val result = client.testCredentials(account, validSecret)
+        assertTrue(result is ProviderResult.Failure.AuthError)
+    }
+}

--- a/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/GitHubCopilotProviderClientTest.kt
+++ b/src/test/kotlin/org/zhavoronkov/tokenpulse/provider/GitHubCopilotProviderClientTest.kt
@@ -1,0 +1,187 @@
+package org.zhavoronkov.tokenpulse.provider
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.zhavoronkov.tokenpulse.model.ConnectionType
+import org.zhavoronkov.tokenpulse.model.ProviderResult
+import org.zhavoronkov.tokenpulse.provider.github.GitHubCopilotProviderClient
+import org.zhavoronkov.tokenpulse.provider.github.GitHubSecrets
+import org.zhavoronkov.tokenpulse.settings.Account
+import org.zhavoronkov.tokenpulse.settings.AuthType
+import java.math.BigDecimal
+
+/**
+ * Unit tests for [GitHubCopilotProviderClient] using MockWebServer.
+ *
+ * Verifies:
+ * - Successful parsing of premium_request and ai_credit usage responses
+ * - Sum-of-netAmount aggregation across items
+ * - Currency and username metadata
+ * - Auth (401/403), rate-limit (429), and server (5xx) error mapping
+ * - Graceful degradation when only ai_credit fetch fails
+ * - Rejection of malformed secret payloads
+ */
+class GitHubCopilotProviderClientTest {
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var client: GitHubCopilotProviderClient
+    private val account = Account(
+        connectionType = ConnectionType.GITHUB_COPILOT_PAT,
+        authType = AuthType.GITHUB_COPILOT_PAT
+    )
+    private val validSecret = GitHubSecrets.encodeCopilot("ghp_testtoken", "octocat")
+
+    @BeforeEach
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+        client = GitHubCopilotProviderClient(
+            baseUrl = mockWebServer.url("/").toString().trimEnd('/')
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun `fetchBalance sums netAmount across premium_request items`() {
+        // premium_request response
+        mockWebServer.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{
+                    "usageItems": [
+                        {"netAmount": 0.04, "product": "copilot"},
+                        {"netAmount": 0.08, "product": "copilot"},
+                        {"netAmount": 0.12, "product": "copilot"}
+                    ]
+                }"""
+            )
+        )
+        // ai_credit response
+        mockWebServer.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"usageItems": [{"netAmount": 1.50}]}"""
+            )
+        )
+
+        val result = client.fetchBalance(account, validSecret)
+
+        assertTrue(result is ProviderResult.Success)
+        val success = result as ProviderResult.Success
+        assertEquals(0, BigDecimal("0.24").compareTo(success.snapshot.balance.credits?.used))
+        assertEquals("USD", success.snapshot.metadata["currency"])
+        assertEquals("octocat", success.snapshot.metadata["username"])
+        assertEquals("3", success.snapshot.metadata["premiumRequestItems"])
+        assertEquals("1.50", success.snapshot.metadata["aiCreditsUsed"])
+    }
+
+    @Test
+    fun `fetchBalance succeeds with zero usage when items array is missing`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("""{}"""))
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("""{}"""))
+
+        val result = client.fetchBalance(account, validSecret)
+
+        assertTrue(result is ProviderResult.Success)
+        val success = result as ProviderResult.Success
+        assertEquals(0, BigDecimal.ZERO.compareTo(success.snapshot.balance.credits?.used))
+    }
+
+    @Test
+    fun `fetchBalance still succeeds when ai_credit call fails`() {
+        mockWebServer.enqueue(
+            MockResponse().setResponseCode(200).setBody(
+                """{"usageItems": [{"netAmount": 5.00}]}"""
+            )
+        )
+        // ai_credit fails with 500 — primary should still return successfully
+        mockWebServer.enqueue(MockResponse().setResponseCode(500))
+
+        val result = client.fetchBalance(account, validSecret)
+
+        assertTrue(result is ProviderResult.Success)
+        val success = result as ProviderResult.Success
+        assertEquals("unavailable", success.snapshot.metadata["aiCreditsUsed"])
+    }
+
+    @Test
+    fun `fetchBalance maps 401 to AuthError`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(401))
+        val result = client.fetchBalance(account, validSecret)
+        assertTrue(result is ProviderResult.Failure.AuthError)
+    }
+
+    @Test
+    fun `fetchBalance maps 403 to AuthError`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(403))
+        val result = client.fetchBalance(account, validSecret)
+        assertTrue(result is ProviderResult.Failure.AuthError)
+    }
+
+    @Test
+    fun `fetchBalance maps 429 to RateLimited with Retry-After hint`() {
+        mockWebServer.enqueue(
+            MockResponse().setResponseCode(429).setHeader("Retry-After", "60")
+        )
+        val result = client.fetchBalance(account, validSecret)
+        assertTrue(result is ProviderResult.Failure.RateLimited)
+        val failure = result as ProviderResult.Failure.RateLimited
+        assertTrue(failure.msg.contains("60"), "Retry-After seconds should be surfaced")
+    }
+
+    @Test
+    fun `fetchBalance maps 500 to NetworkError`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(500))
+        val result = client.fetchBalance(account, validSecret)
+        assertTrue(result is ProviderResult.Failure.NetworkError)
+    }
+
+    @Test
+    fun `fetchBalance rejects malformed secret payload with AuthError`() {
+        val result = client.fetchBalance(account, "not-a-json-blob")
+        assertTrue(result is ProviderResult.Failure.AuthError)
+    }
+
+    @Test
+    fun `fetchBalance rejects secret missing username with AuthError`() {
+        val result = client.fetchBalance(account, """{"pat":"ghp_x"}""")
+        assertTrue(result is ProviderResult.Failure.AuthError)
+    }
+
+    @Test
+    fun `request sets Authorization Bearer header and GitHub API version`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("""{"usageItems": []}"""))
+        mockWebServer.enqueue(MockResponse().setResponseCode(200).setBody("""{"usageItems": []}"""))
+
+        client.fetchBalance(account, validSecret)
+
+        val request = mockWebServer.takeRequest()
+        assertEquals("Bearer ghp_testtoken", request.getHeader("Authorization"))
+        assertNotNull(request.getHeader("X-GitHub-Api-Version"))
+        assertEquals("application/vnd.github+json", request.getHeader("Accept"))
+        assertTrue(request.path?.contains("/users/octocat/settings/billing/premium_request") == true)
+    }
+
+    @Test
+    fun `testCredentials returns success without full snapshot`() {
+        mockWebServer.enqueue(
+            MockResponse().setResponseCode(200).setBody("""{"usageItems": []}""")
+        )
+        val result = client.testCredentials(account, validSecret)
+        assertTrue(result is ProviderResult.Success)
+    }
+
+    @Test
+    fun `testCredentials returns AuthError on 401`() {
+        mockWebServer.enqueue(MockResponse().setResponseCode(401))
+        val result = client.testCredentials(account, validSecret)
+        assertTrue(result is ProviderResult.Failure.AuthError)
+    }
+}


### PR DESCRIPTION
## Summary

Adds GitHub Copilot billing tracking as a new provider with two connection types:

- **GitHub Copilot (personal)** — per-user premium-request and AI-credit spend
- **GitHub Copilot (org budget)** — organization budget vs. consumed tracking

## Details

**Model layer**
- New `Provider.GITHUB` enum entry (`GH`)
- Two `ConnectionType` values: `GITHUB_COPILOT_PAT`, `GITHUB_COPILOT_ORG_BUDGET`
- Two `AuthType` values with matching secret-blob docs
- Updated all exhaustive `when` blocks (`ProviderRegistry`, `BalanceRefreshService`, `AccountEditDialog`)

**Provider clients** (`provider/github/`)
- `GitHubSecrets` — shared encode/parse helpers for the JSON secret blobs
- `GitHubCopilotProviderClient` — hits `premium_request/usage` + `ai_credit/usage`, sums `netAmount`, degrades gracefully if the ai_credit call fails
- `GitHubCopilotBudgetProviderClient` — hits org `budgets`, filters to Copilot SKUs, follows RFC 5988 `Link` pagination, computes `remaining = total - consumed`

Both map `401/403 → AuthError`, `429 → RateLimited` (surfaces `Retry-After`), `5xx → NetworkError`.

**UI**
- `GitHubCopilotConnectDialog` (username + PAT) and `GitHubCopilotOrgConnectDialog` (org + PAT)
- `GitHubProviderPanel` helper extraction keeps `AccountEditDialog` under detekt function-count threshold (no `@Suppress` added)

## Testing

- 23 new test cases across `GitHubCopilotProviderClientTest` and `GitHubCopilotBudgetProviderClientTest` (aggregation, SKU filtering, pagination, error mapping, malformed secrets, header/path assertions, `testCredentials`)
- `ProviderTest` updated for the new provider
- `./gradlew build` → **BUILD SUCCESSFUL**, 776 tests passing, detekt clean