### PR TITLE
chore: prepare v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Jump to the release that interests you:
 
 | Release | Highlights |
 |---------|-----------|
-| [0.5.0](#050---2026-08-18) | DeepSeek & GitHub Copilot providers, platform 2025.3, build hardening |
+| [0.5.0](#050---2026-08-18) | DeepSeek & GitHub Copilot providers, platform 2025.3, progress bar fix, build hardening |
 | [0.4.0](#040---2026-07-23) | Redesigned tooltip, session auto-refresh, multi-account support |
 | [0.3.1](#031---2026-07-08) | ClinePass usage limits, improved CLI detection |
 | [0.3.0](#030---2026-06-22) | Xiaomi MiMo provider, session capture, status bar formats |
@@ -30,7 +30,7 @@ Jump to the release that interests you:
 
 ## [0.5.0] - 2026-08-18
 
-> **Highlights:** New DeepSeek & GitHub Copilot providers • Platform raised to 2025.3 • Build hardening (non-public API & Detekt gates) • UI fixes
+> **Highlights:** New DeepSeek & GitHub Copilot providers • Platform raised to 2025.3 • Build hardening (non-public API & Detekt gates) • Progress bar & UI fixes
 
 ### Added
 - **DeepSeek provider support** — track your DeepSeek API usage and quota
@@ -44,6 +44,13 @@ Jump to the release that interests you:
   also kept the agent-convention docs out of the repository.
 
 ### Changed
+- **Tooltip progress bars unified on a single remaining% convention** — every provider row in
+  the status-bar popup (Claude, Codex, Cline, Xiaomi) now fills and labels its progress bar
+  the same way: **percent remaining**. Previously Claude/Codex filled the bar with used% but
+  labeled it remaining%, Cline used used% for both, and Xiaomi used remaining% for both —
+  three inconsistent behaviors in one popup. Thresholds are now shared (red ≤10%, orange ≤30%,
+  green otherwise), and the row model collapsed from `BalanceBar` + `UsageBar` into a single
+  `UsageBar`.
 - **⚠️ Minimum IntelliJ platform is now 2025.3 (build 253)**, up from 2024.2 (build 242).
   IDEs from 2024.2 through 2025.2 will stay on the last compatible release and no longer
   receive updates. This was required to replace `SimpleListCellRenderer.create(...)`, which
@@ -82,6 +89,15 @@ Jump to the release that interests you:
   connection-type change under the 2025.3 SDK (the DSL `comment()` label inserts `<html>`
   itself). The manual wrapper is removed, and the dialog now re-packs after the hint changes so
   it shrinks back to fit shorter hints instead of staying at its tallest size.
+- **Xiaomi Connect dialog no longer emits an error balloon on JCEF-unavailable builds** — the
+  fallback branch passed a literal `<html>...</html>` wrapper into the UI DSL `comment()`,
+  which IntelliJ rejects at runtime (`Invalid html: tag <html> inserted automatically`). The
+  wrapper is stripped, and a shared `DslCommentText.sanitize()` helper plus a source-scanning
+  regression test (`DslCommentHtmlGuardTest`) now catch any future occurrence at build time.
+- **`platformTest` had been silently running zero tests** — the class-name-based JUnit filter
+  was replaced with a working one, and the missing `junit-vintage-engine` dependency plus
+  IntelliJ sandbox JVM wiring were added so the platform smoke tests actually execute in `check`
+  / CI. `check` was previously reporting green on zero platform assertions.
 
 ### Removed
 - Individual TokenPulse settings are no longer indexed for Settings search

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to the TokenPulse plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 📋 Quick Navigation
+
+Jump to the release that interests you:
+
+| Release | Highlights |
+|---------|-----------|
+| [0.5.0](#050---2026-08-18) | DeepSeek & GitHub Copilot providers, platform 2025.3, build hardening |
+| [0.4.0](#040---2026-07-23) | Redesigned tooltip, session auto-refresh, multi-account support |
+| [0.3.1](#031---2026-07-08) | ClinePass usage limits, improved CLI detection |
+| [0.3.0](#030---2026-06-22) | Xiaomi MiMo provider, session capture, status bar formats |
+| [0.2.0](#020---2026-04-22) | Codex CLI integration, credential cooldowns |
+| [0.1.0](#010---2026-03-10-initial--release) | Initial release — multi-provider tracking, status bar widget |
+
 ## [Unreleased]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+## [0.5.0] - 2026-08-18
+
+### Added
+- **DeepSeek provider support** — track your DeepSeek API usage and quota
+  alongside the other LLM providers.
+- **GitHub Copilot provider** — track Copilot spend for both personal
+  accounts and organizations from the status bar, with a dedicated
+  connect dialog for each flavor.
 - **Architecture Decision Records** — `docs/adr/` now holds the ADRs that
   `docs/agents/domain.md` has always required. They were previously impossible to commit:
   `.gitignore` listed `docs/` under "Build directories" and swallowed the whole tree, which
@@ -41,6 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   own copy of the Gradle home, which put the repository at 24 GB across 60 entries against a
   ~10 GB budget — so entries were evicted before they could be reused, making runs cold *and*
   costing ~2 min per run in uploads.
+- **Triage label vocabulary expanded** with type/domain/priority namespaces,
+  giving contributors a shared taxonomy for classifying issues and PRs.
 
 ### Fixed
 - Removed all use of platform API that is deprecated or scheduled for removal, so the plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Jump to the release that interests you:
 
 ## [0.5.0] - 2026-08-18
 
+> **Highlights:** New DeepSeek & GitHub Copilot providers • Platform raised to 2025.3 • Build hardening (non-public API & Detekt gates) • UI fixes
+
 ### Added
 - **DeepSeek provider support** — track your DeepSeek API usage and quota
   alongside the other LLM providers.
@@ -87,6 +89,8 @@ Jump to the release that interests you:
   The TokenPulse settings page itself is still findable.
 
 ## [0.4.0] - 2026-07-23
+
+> **Highlights:** Redesigned status-bar tooltip with native rendering • Session auto-refresh for Nebius & Xiaomi • Claude Code multi-account support • OAuth API integration for Claude & Codex • Unified Xiaomi MiMo provider
 
 ### Added
 - **Redesigned status-bar tooltip** — hovering the status-bar widget now opens an all-new,
@@ -162,6 +166,8 @@ Jump to the release that interests you:
 
 ## [0.3.1] - 2026-07-08
 
+> **Highlights:** ClinePass usage limits • Improved CLI detection reliability • Dialog & logging fixes
+
 ### Added
 - **ClinePass usage limits** for Cline API key accounts — optional 5-hour, weekly, and monthly
   usage (percent + reset time) displayed in the tooltip when available
@@ -189,6 +195,8 @@ Jump to the release that interests you:
 
 ## [0.3.0] - 2026-06-22
 
+> **Highlights:** Xiaomi MiMo provider (pay-as-you-go + Token Plan) • Session capture flow • Status bar format options • Short number formatting
+
 ### Added
 - **Xiaomi MiMo provider** — Two connection types: API (pay-as-you-go) and Token Plan (subscription Credits)
 - **Session capture flow** — XiaomiConnectDialog for capturing platform session via cURL
@@ -214,6 +222,8 @@ Jump to the release that interests you:
 
 ## [0.2.0] - 2026-04-22
 
+> **Highlights:** Codex CLI integration for ChatGPT • Credential failure cooldowns • Improved Nebius handling
+
 ### Added
 - **Codex CLI integration** — ChatGPT now uses Codex CLI for simpler, more reliable setup without OAuth complexity
 - **Credential failure cooldowns** — Smart throttling reduces notification spam for repeated credential errors
@@ -235,6 +245,8 @@ Jump to the release that interests you:
 ---
 
 ## [0.1.0] - 2026-03-10 (Initial β Release)
+
+> **Highlights:** Multi-provider balance tracking • 6 providers supported (OpenRouter, Cline, OpenAI, ChatGPT, Nebius, Claude) • Status bar widget & dashboard • Settings page & secure storage
 
 ### Added
 - **Multi-provider balance tracking** — Monitor token balances and credit usage across multiple AI providers directly in your IDE status bar.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -101,7 +101,7 @@ token-pulse/
 
 All versioning and platform compatibility info is centralized in **`gradle.properties`**:
 ```properties
-pluginVersion = 0.4.0
+pluginVersion = 0.5.0
 pluginSinceBuild = 253
 platformVersion = 2025.3.6
 ```
@@ -135,6 +135,6 @@ Code quality is enforced via **Detekt**. The build will fail if any issues are f
 
 1. Update version in `gradle.properties`.
 2. Add a new entry to `CHANGELOG.md`.
-3. Create a git tag: `git tag v0.4.0` and push it.
+3. Create a git tag: `git tag v0.5.0` and push it.
 4. CI will automatically create a GitHub Release and attach the ZIP artifact.
 5. **Manually publish** the signed artifact to the JetBrains Marketplace (see `MARKETPLACE.md`).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # TokenPulse
 
 [![JetBrains Plugin](https://img.shields.io/badge/JetBrains-Plugin-orange.svg)](https://plugins.jetbrains.com/plugin/30615-tokenpulse)
-[![Version](https://img.shields.io/badge/version-0.4.0-blue.svg)](https://github.com/DimazzzZ/tokenpulse-intellij-plugin/releases)
+[![Version](https://img.shields.io/badge/version-0.5.0-blue.svg)](https://github.com/DimazzzZ/tokenpulse-intellij-plugin/releases)
 [![CI](https://github.com/DimazzzZ/tokenpulse-intellij-plugin/actions/workflows/ci.yml/badge.svg)](https://github.com/DimazzzZ/tokenpulse-intellij-plugin/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-> ⚠️ **Beta Release** — This is an early release (v0.4.0). Features may change and some functionality may be incomplete. Please [report issues](https://github.com/DimazzzZ/tokenpulse-intellij-plugin/issues) on GitHub.
+> ⚠️ **Beta Release** — This is an early release (v0.5.0). Features may change and some functionality may be incomplete. Please [report issues](https://github.com/DimazzzZ/tokenpulse-intellij-plugin/issues) on GitHub.
 
 **TokenPulse** is an IntelliJ IDEA plugin that aggregates token balances and credit usage across multiple AI providers directly in your IDE status bar.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ kotlin.compiler.execution.strategy=in-process
 # Plugin metadata
 pluginGroup = org.zhavoronkov.tokenpulse
 pluginName = TokenPulse
-pluginVersion = 0.4.0
+pluginVersion = 0.5.0
 pluginRepositoryUrl = https://github.com/DimazzzZ/tokenpulse-intellij-plugin
 
 # Compatibility

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/startup/WhatsNewNotificationActivity.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/startup/WhatsNewNotificationActivity.kt
@@ -39,19 +39,14 @@ class WhatsNewNotificationActivity : ProjectActivity {
             .getNotificationGroup("TokenPulse Updates")
             .createNotification(
                 "TokenPulse Updated to v$version",
-                """
+               """
                 <b>Thank you for using TokenPulse!</b><br/><br/>
-                <b>New in v$version &mdash; a redesigned status-bar tooltip</b><br/>
-                Hover the status bar for an all-new, native view of every quota:<br/>
-                • <b>Real progress bars</b> for each provider and account &mdash; no more plain text<br/>
-                • <b>Theme-aware colors</b> that turn orange, then red as you approach a limit<br/>
-                • <b>Humanized reset times</b> like &ldquo;Today 14:30&rdquo; or &ldquo;Tomorrow 09:00&rdquo;<br/>
-                • <b>Grouped by provider</b>, one clear section per account<br/><br/>
-                <b>Also new:</b><br/>
-                • Unified Xiaomi MiMo &mdash; pay-as-you-go balance and Token Plan Credits in one account<br/>
-                • Claude Code multi-account &mdash; auto-discovers every logged-in account<br/>
-                • Codex &amp; Claude OAuth &mdash; usage read from your stored logins, tokens auto-refreshed<br/>
-                • Nebius &amp; Xiaomi silent session refresh &mdash; stay connected without re-logging in
+                <b>What&rsquo;s new in v$version:</b><br/>
+                • <b>DeepSeek provider</b> &mdash; track your DeepSeek API usage and quota<br/>
+                • <b>GitHub Copilot provider</b> &mdash; personal and organization budget tracking<br/>
+                • <b>Platform raised to IntelliJ 2025.3</b> &mdash; required for forward compatibility<br/>
+                • <b>Build hardened</b> &mdash; non-public API and Detekt now gate the build<br/>
+                • <b>UI fix</b> &mdash; Add/Edit Account dialog hint no longer floods the log or gets stuck tall
                 """.trimIndent(),
                 NotificationType.INFORMATION
             )

--- a/src/main/kotlin/org/zhavoronkov/tokenpulse/startup/WhatsNewNotificationActivity.kt
+++ b/src/main/kotlin/org/zhavoronkov/tokenpulse/startup/WhatsNewNotificationActivity.kt
@@ -39,7 +39,7 @@ class WhatsNewNotificationActivity : ProjectActivity {
             .getNotificationGroup("TokenPulse Updates")
             .createNotification(
                 "TokenPulse Updated to v$version",
-               """
+                """
                 <b>Thank you for using TokenPulse!</b><br/><br/>
                 <b>What&rsquo;s new in v$version:</b><br/>
                 • <b>DeepSeek provider</b> &mdash; track your DeepSeek API usage and quota<br/>


### PR DESCRIPTION
## Release v0.5.0

Bump `pluginVersion` to 0.5.0 and update all version references, changelog, and the What's New notification body.

### Changes

- **gradle.properties** — `pluginVersion = 0.5.0`
- **CHANGELOG.md** — added DeepSeek, GitHub Copilot, and label-taxonomy entries; closed Unreleased as `[0.5.0] - 2026-08-18`; opened fresh empty Unreleased
- **README.md** — version badge + Beta callout → 0.5.0
- **DEVELOPMENT.md** — example `pluginVersion` and `git tag` → 0.5.0
- **WhatsNewNotificationActivity.kt** — rewrote HTML bullet body for v0.5.0

### v0.5.0 highlights

- DeepSeek provider support
- GitHub Copilot provider (personal + org budget)
- Minimum platform raised to IntelliJ 2025.3
- Non-public API and Detekt now gate the build
- Configuration cache enabled for local builds
- Plugin Verifier runs on PRs
- CI cache write-only from main
- Add/Edit Account dialog hint UI fix

### After merge

Tag `v0.5.0` on the merge commit and push — `release.yml` handles the rest.